### PR TITLE
Refactor core

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -80,22 +80,22 @@ const txhandler = (msg, txobj) => {
     const newobj = {from, to, value, data: data ? printval(data.slice(0,50)) : null};
     return msg + ' ' + JSON.stringify(newobj);
 }
-const contexthandler = (msg, txobj) => {
+const contexthandler = (msg, txobj={}) => {
     const printobj = {};
     Object.keys(txobj).forEach(key => {
         const {address, balance, storage, runtimeCode} = txobj[key];
-        printobj[key] = {address, balance: balance.toString(), storage, runtimeCode: runtimeCode ? printval(runtimeCode.slice(0, 50)) : null};
+        printobj[key] = {address, balance: balance ? balance.toString() : '0', storage, runtimeCode: runtimeCode ? printval(runtimeCode.slice(0, 50)) : null};
     })
     return msg + ' ' + printval(printobj);
 }
 
 const Logger = logg('', LEVELS.SILENT, null, [], []);
 Logger.spawn('jsvm');
-Logger.spawn('ewasmvm');
+Logger.spawn('ewasmjsvm');
 Logger.spawn('evmjs');
 Logger.get('jsvm').spawn('tx', null, txhandler);
-Logger.get('ewasmvm').spawn('tx', null, txhandler);
-Logger.get('ewasmvm').spawn('context', null, contexthandler);
+Logger.get('ewasmjsvm').spawn('tx', null, txhandler);
+Logger.get('ewasmjsvm').spawn('context', null, contexthandler);
 Logger.get('evmjs').spawn('tx', null, txhandler);
 Logger.get('evmjs').spawn('context', null, contexthandler);
 

--- a/src/config.js
+++ b/src/config.js
@@ -89,7 +89,7 @@ const contexthandler = (msg, txobj={}) => {
     return msg + ' ' + printval(printobj);
 }
 
-const Logger = logg('', LEVELS.SILENT, null, [], []);
+const Logger = logg('', LEVELS.DEBUG, null, [], []);
 Logger.spawn('jsvm');
 Logger.spawn('ewasmjsvm');
 Logger.spawn('evmjs');

--- a/src/config.js
+++ b/src/config.js
@@ -92,8 +92,11 @@ const contexthandler = (msg, txobj) => {
 const Logger = logg('', LEVELS.SILENT, null, [], []);
 Logger.spawn('jsvm');
 Logger.spawn('ewasmvm');
+Logger.spawn('evmjs');
 Logger.get('jsvm').spawn('tx', null, txhandler);
 Logger.get('ewasmvm').spawn('tx', null, txhandler);
 Logger.get('ewasmvm').spawn('context', null, contexthandler);
+Logger.get('evmjs').spawn('tx', null, txhandler);
+Logger.get('evmjs').spawn('context', null, contexthandler);
 
 module.exports = {Logger, logg};

--- a/src/config.js
+++ b/src/config.js
@@ -96,4 +96,4 @@ Logger.get('jsvm').spawn('tx', null, txhandler);
 Logger.get('ewasmvm').spawn('tx', null, txhandler);
 Logger.get('ewasmvm').spawn('context', null, contexthandler);
 
-module.exports = Logger;
+module.exports = {Logger, logg};

--- a/src/config.js
+++ b/src/config.js
@@ -89,7 +89,7 @@ const contexthandler = (msg, txobj) => {
     return msg + ' ' + printval(printobj);
 }
 
-const Logger = logg('', LEVELS.DEBUG, null, [], ['transferValue', 'storeStateChanges', 'context', 'logs', 'call']);
+const Logger = logg('', LEVELS.SILENT, null, [], []);
 Logger.spawn('jsvm');
 Logger.spawn('ewasmvm');
 Logger.get('jsvm').spawn('tx', null, txhandler);

--- a/src/config.js
+++ b/src/config.js
@@ -89,7 +89,7 @@ const contexthandler = (msg, txobj={}) => {
     return msg + ' ' + printval(printobj);
 }
 
-const Logger = logg('', LEVELS.DEBUG, null, [], []);
+const Logger = logg('', LEVELS.SILENT, null, [], []);
 Logger.spawn('jsvm');
 Logger.spawn('ewasmjsvm');
 Logger.spawn('evmjs');

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,7 @@
 const ERROR = {
     ASYNC_CALL: 'Asynchronous Call Stop',
     ASYNC_RESOURCE: 'Asynchronous Resource Stop',
+    STOP: '*stop*',
 }
 
 module.exports = {ERROR};

--- a/src/evm.js
+++ b/src/evm.js
@@ -1,0 +1,714 @@
+const BN = require('bn.js');
+const {
+    uint8ArrayToHex,
+    hexToUint8Array,
+    toBN,
+    BN2uint8arr,
+}  = require('./utils.js');
+const evmasm = require('evmasm');
+
+const initializeImports = (
+    vmcore,
+    txObj,
+    internalCallWrap,
+    asyncResourceWrap,
+    getMemory,
+    getCache,
+    finishAction,
+    revertAction,
+    logger,
+) => {
+    const jsvm_env = vmcore.call(txObj, internalCallWrap, asyncResourceWrap, getMemory, getCache);
+    const api = {ethereum: {}};
+
+    api.ethereum = {
+        storeMemory: function (offset, bytes, stack) {
+            jsvm_env.storeMemory(BN2uint8arr(bytes), offset);
+            logger.debug('MSTORE', [bytes, offset], [], getCache(), getMemory(), stack);
+        },
+        storeMemory8: function (offset, bytes, stack) {
+            jsvm_env.storeMemory8(BN2uint8arr(bytes), offset);
+            logger.debug('MSTORE8', [bytes, offset], [], getCache(), getMemory(), stack);
+        },
+        loadMemory: function (offset, stack) {
+            const result = jsvm_env.loadMemory(offset);
+            logger.debug('MLOAD', [offset], [result], getCache(), getMemory(), stack);
+            return toBN(result);
+        },
+        useGas: function (amount, stack) {
+            jsvm_env.useGas(amount);
+            logger.debug('USEGAS', [amount], [], getCache(), getMemory(), stack);
+        },
+        getAddress: function (stack) {
+            const address = jsvm_env.getAddress();
+            logger.debug('ADDRESS', [], [address], getCache(), getMemory(), stack);
+            return toBN(address);
+        },
+        // result is u128
+        getExternalBalance: function (_address, stack) {
+            const address = BN2uint8arr(_address);
+            const balance = toBN(jsvm_env.getExternalBalance(address));
+            logger.debug('BALANCE', [_address], [balance], getCache(), getMemory(), stack);
+            return balance;
+        },
+        // result i32 Returns 0 on success and 1 on failure
+        getBlockHash: function (number, stack) {
+            const hash = toBN(jsvm_env.getBlockHash(number));
+            logger.debug('BLOCKHASH', [number], [hash], getCache(), getMemory(), stack);
+            return hash;
+        },
+        // result i32 Returns 0 on success, 1 on failure and 2 on revert
+        call: function (
+            gas_limit,
+            address, // the memory offset to load the address from (address)
+            value,
+            dataOffset,
+            dataLength,
+            outputOffset,
+            outputLength,
+            stack
+        ) {
+            const result = jsvm_env.call(
+                gas_limit,
+                BN2uint8arr(address),
+                BN2uint8arr(value),
+                dataOffset,
+                dataLength,
+                outputOffset,
+                outputLength,
+            );
+            logger.debug('CALL', [gas_limit,
+                address,
+                value,
+                dataOffset,
+                dataLength,
+                outputOffset,
+                outputLength,], [result], getCache(), getMemory(), stack);
+            return toBN(result);
+        },
+        callDataCopy: function (resultOffset, dataOffset, length, stack) {
+            const result = jsvm_env.callDataCopy(resultOffset, dataOffset, length);
+            logger.debug('CALLDATACOPY', [resultOffset, dataOffset, length], [result], getCache(), getMemory(), stack);
+            return toBN(result);
+        },
+        // returns i32
+        getCallDataSize: function (stack) {
+            const result = toBN(jsvm_env.getCallDataSize());
+            logger.debug('CALLDATASIZE', [], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        callDataLoad: function(dataOffset) {
+            const result = jsvm_env.callDataLoad(dataOffset);
+            logger.debug('CALLDATALOAD', [dataOffset], [result], getCache(), getMemory());
+            return toBN(result);
+        },
+        // result i32 Returns 0 on success, 1 on failure and 2 on revert
+        callCode: function (
+            gas_limit,
+            address,
+            value,
+            dataOffset,
+            dataLength,
+            outputOffset,
+            outputLength,
+            stack
+        ) {
+            const result = jsvm_env.callCode(
+                gas_limit,
+                BN2uint8arr(address),
+                BN2uint8arr(value),
+                dataOffset,
+                dataLength,
+                outputOffset,
+                outputLength
+            );
+            logger.debug('CALLCODE', [gas_limit_i64, addressOffset_i32ptr_address, valueOffset_i32ptr_u128, dataOffset_i32ptr_bytes, dataLength_i32], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        // result i32 Returns 0 on success, 1 on failure and 2 on revert
+        callDelegate: function (
+            gas_limit_i64,
+            address,
+            dataOffset,
+            dataLength,
+            outputOffset,
+            outputLength,
+            stack
+        ) {
+            const result = jsvm_env.callDelegate(
+                gas_limit_i64,
+                BN2uint8arr(address),
+                dataOffset,
+                dataLength,
+                outputOffset,
+                outputLength
+            );
+            logger.debug('DELEGATECALL', [
+                gas_limit_i64,
+                address,
+                dataOffset,
+                dataLength,
+                outputOffset,
+                outputLength], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        // result i32 Returns 0 on success, 1 on failure and 2 on revert
+        callStatic: function (
+            gas_limit_i64,
+            address,
+            dataOffset,
+            dataLength,
+            outputOffset,
+            outputLength,
+            stack
+        ) {
+            const result = jsvm_env.callStatic(
+                gas_limit_i64,
+                BN2uint8arr(address),
+                dataOffset,
+                dataLength,
+                outputOffset,
+                outputLength
+            );
+
+            logger.debug('STATICCALL', [
+                gas_limit_i64,
+                address,
+                dataOffset,
+                dataLength,
+                outputOffset,
+                outputLength], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        storageStore: function (pathOffset, value, stack) {
+            jsvm_env.storageStore(BN2uint8arr(pathOffset), BN2uint8arr(value));
+            logger.debug('SSTORE', [pathOffset, value], [], getCache(), getMemory(), stack);
+        },
+        storageLoad: function (pathOffset, stack) {
+            const value = jsvm_env.storageLoad(BN2uint8arr(pathOffset));
+            logger.debug('SLOAD', [pathOffset], [value], getCache(), getMemory(), stack);
+            return toBN(value);
+        },
+        getCaller: function (stack) {
+            const address = jsvm_env.getCaller();
+            logger.debug('CALLER', [], [address], getCache(), getMemory(), stack);
+            return toBN(address);
+        },
+        getCallValue: function (stack) {
+            const value = jsvm_env.getCallValue();
+            logger.debug('CALLVALUE', [], [value], getCache(), getMemory(), stack);
+            return toBN(value);
+        },
+        codeCopy: function (resultOffset, codeOffset, length, stack) {
+            jsvm_env.codeCopy(resultOffset, codeOffset, length);
+            logger.debug('CODECOPY', [resultOffset, codeOffset, length], [], getCache(), getMemory(), stack);
+        },
+        // returns i32 - code size current env
+        getCodeSize: function(stack) {
+            const result = jsvm_env.getCodeSize();
+            logger.debug('CODESIZE', [], [result], getCache(), getMemory(), stack);
+            return toBN(result);
+        },
+        // block’s beneficiary address
+        getBlockCoinbase: function(stack) {
+            const value = jsvm_env.getBlockCoinbase();
+            logger.debug('COINBASE', [], [value], getCache(), getMemory(), stack);
+            return toBN(value);
+        },
+        create: function (
+            value,
+            dataOffset,
+            dataLength,
+            stack
+        ) {
+            const address = jsvm_env.create(value, dataOffset, dataLength);
+
+            logger.debug('CREATE', [value,
+                dataOffset,
+                dataLength,
+            ], [address], getCache(), getMemory(), stack);
+
+            return toBN(address);
+        },
+        getBlockDifficulty: function (stack) {
+            const value = jsvm_env.getBlockDifficulty();
+            logger.debug('DIFFICULTY', [], [value], getCache(), getMemory(), stack);
+            return toBN(value);
+        },
+        externalCodeCopy: function (
+            address,
+            resultOffset,
+            codeOffset,
+            dataLength,
+            stack
+        ) {
+            jsvm_env.externalCodeCopy(
+                BN2uint8arr(address),
+                resultOffset,
+                codeOffset,
+                dataLength,
+            )
+            logger.debug('EXTCODECOPY', [address,
+                resultOffset,
+                codeOffset,
+                dataLength,
+            ], [], getCache(), getMemory(), stack);
+        },
+        // Returns extCodeSize i32
+        getExternalCodeSize: function (address, stack) {
+            const result = jsvm_env.getExternalCodeSize(BN2uint8arr(address));
+            logger.debug('EXTCODESIZE', [address], [result], getCache(), getMemory(), stack);
+            return toBN(result);
+        },
+        // result gasLeft i64
+        getGasLeft: function (stack) {
+            const result = jsvm_env.getGasLeft();
+            logger.debug('GAS', [], [result], getCache(), getMemory(), stack);
+            return toBN(result);
+        },
+        // result blockGasLimit i64
+        getBlockGasLimit: function (stack) {
+            const result = jsvm_env.getBlockGasLimit();
+            logger.debug('GASLIMIT', [], [result], getCache(), getMemory(), stack);
+            return toBN(result);
+        },
+        getTxGasPrice: function (stack) {
+            const result = jsvm_env.getTxGasPrice();
+            logger.debug('GASPRICE', [], [result], getCache(), getMemory(), stack);
+            return toBN(result);
+        },
+        log: function (
+            dataOffset,
+            dataLength,
+            ...topics
+        ) {
+            const stack = topics.pop();
+            const numberOfTopics = topics.length;
+            jsvm_env.log(
+                dataOffset,
+                dataLength,
+                numberOfTopics,
+                topics,
+            );
+            logger.debug('LOG' + numberOfTopics, [dataOffset,
+                dataLength,
+                numberOfTopics,
+                ...topics
+            ], [], getCache(), getMemory(), stack);
+        },
+        log0: function(dataOffset, dataLength, ...topics) {
+            api.ethereum.log(dataOffset, dataLength, ...topics);
+        },
+        log1: function(dataOffset, dataLength, ...topics) {
+            api.ethereum.log(dataOffset, dataLength, ...topics);
+        },
+        log2: function(dataOffset, dataLength, ...topics) {
+            api.ethereum.log(dataOffset, dataLength, ...topics);
+        },
+        log3: function(dataOffset, dataLength, ...topics) {
+            api.ethereum.log(dataOffset, dataLength, ...topics);
+        },
+        log4: function(dataOffset, dataLength, ...topics) {
+            api.ethereum.log(dataOffset, dataLength, ...topics);
+        },
+        // result blockNumber i64
+        getBlockNumber: function (stack) {
+            const result = jsvm_env.getBlockNumber();
+            logger.debug('NUMBER', [], [result], getCache(), getMemory(), stack);
+            return toBN(result);
+        },
+        getTxOrigin: function (stack) {
+            const address = jsvm_env.getTxOrigin();
+            logger.debug('ORIGIN', [], [address], getCache(), getMemory(), stack);
+            return toBN(address);
+        },
+        finish: function (dataOffset, dataLength, stack) {
+            const res = jsvm_env.finish(dataOffset, dataLength);
+            logger.debug('FINISH', [dataOffset, dataLength], [res], getCache(), getMemory(), stack);
+            finishAction(res);  // TODO tohex
+        },
+        revert: function (dataOffset, dataLength, stack) {
+            const res = jsvm_env.revert(dataOffset, dataLength);
+            console.log('revert');
+            logger.debug('REVERT', [dataOffset, dataLength], [res], getCache(), getMemory(), stack);
+            revertAction(res);
+        },
+        // result dataSize i32
+        getReturnDataSize: function (stack) {
+            const result = jsvm_env.getReturnDataSize();
+            logger.debug('RETURNDATASIZE', [], [result], getCache(), getMemory(), stack);
+            return toBN(address);
+        },
+        returnDataCopy: function (resultOffset, dataOffset, length, stack) {
+            jsvm_env.returnDataCopy(resultOffset, dataOffset, length);
+            logger.debug('RETURNDATACOPY', [resultOffset, dataOffset, length], [], getCache(), getMemory(), stack);
+        },
+        selfDestruct: function (address, stack) {
+            jsvm_env.selfDestruct(BN2uint8arr(address));
+            logger.debug('SELFDESTRUCT', [address], [], getCache(), getMemory(), stack);
+            finishAction();
+        },
+        // result blockTimestamp i64,
+        getBlockTimestamp: function (stack) {
+            const result = jsvm_env.getBlockTimestamp();
+            logger.debug('TIMESTAMP', [], [result], getCache(), getMemory(), stack);
+            return toBN(result);
+        },
+        return: (offset, length, stack) => {
+            const result = uint8ArrayToHex(jsvm_env.finish(offset, length));
+            logger.debug('RETURN', [offset, length], [result], getCache(), getMemory(), stack);
+            return finishAction(result);
+        },
+        revert: (offset, length, stack) => {
+            const result = uint8ArrayToHex(jsvm_env.revert(offset, length));
+            logger.debug('REVERT', [offset, length], [result], getCache(), getMemory(), stack);
+            return revertAction(result);
+        },
+        stop: (stack) => {
+            return api.ethereum.return(toBN(0), toBN(0), stack);
+        },
+        keccak256: () => {
+            throw new Error('Not implemented');
+        },
+        uint256Max: () => new BN('10000000000000000000000000000000000000000000000000000000000000000', 16),
+        // mimick evm overflow
+        add: (a, b, stack) => {
+            const result = a.add(b).mod(api.ethereum.uint256Max());
+            logger.debug('ADD', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        mul: (a, b, stack) => {
+            const result = a.mul(b).mod(api.ethereum.uint256Max());
+            logger.debug('MUL', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        // mimick evm underflow
+        sub: (a, b, stack) => {
+            const result = a.sub(b).mod(api.ethereum.uint256Max());
+            logger.debug('SUB', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        div: (a, b, stack) => {
+            const result = a.abs().div(b.abs());
+            logger.debug('DIV', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        sdiv: (a, b, stack) => {
+            const result = a.div(b);
+            logger.debug('SDIV', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        mod: (a, b, stack) => {
+            const result = a.abs().mod(b.abs());
+            logger.debug('MOD', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        smod: (a, b, stack) => {
+            const result = a.mod(b);
+            logger.debug('SMOD', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        addmod: (a, b, c, stack) => {
+            const result = api.ethereum.mod(api.ethereum.add(a, b), c);
+            logger.debug('ADDMOD', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        mulmod: (a, b, c, stack) => {
+            const result = api.ethereum.mod(api.ethereum.mul(a, b), c);
+            logger.debug('MULMOD', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        exp: (a, b, stack) => {
+            if (b.lt(toBN(0))) return toBN(0);
+            const result = a.exp(b);
+            logger.debug('EXP', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        signextend: (a, b) => {
+            throw new Error('signextend unimplemented');
+        },
+        lt: (a, b, stack) => {
+            let result = a.abs().lt(b.abs());
+            result = toBN(result ? 1 : 0);
+            logger.debug('LT', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        gt: (a, b, stack) => {
+            let result = a.abs().gt(b.abs());
+            result = toBN(result ? 1 : 0);
+            logger.debug('GT', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        slt: (a, b, stack) => {
+            let result = a.lt(b);
+            result = toBN(result ? 1 : 0);
+            logger.debug('SLT', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        sgt: (a, b, stack) => {
+            let result = a.gt(b);
+            result = toBN(result ? 1 : 0);
+            logger.debug('SGT', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        eq: (a, b, stack) => {
+            let result = a.eq(b);
+            result = toBN(result ? 1 : 0);
+            logger.debug('EQ', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        iszero: (a, stack) => {
+            let result = a.isZero();
+            result = toBN(result ? 1 : 0);
+            logger.debug('SAR', [a], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        and: (a, b, stack) => {
+            const result = a.and(b);
+            logger.debug('AND', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        or: (a, b, stack) => {
+            const result = a.or(b);
+            logger.debug('OR', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        xor: (a, b, stack) => {
+            const result = a.xor(b);
+            logger.debug('XOR', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        not: (a, stack) => {
+            const result = a.notn(256);
+            logger.debug('NOT', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        byte: (nth, bb, stack) => {
+            const result = BN2uint8arr(bb).slice(nth, nth + 1);
+            logger.debug('BYTE', [a, b], [result], getCache(), getMemory(), stack);
+            return toBN(result);
+        },
+        shl: (a, b, stack) => {
+            const result = b.shln(a.toNumber());
+            logger.debug('SHL', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        shr: (a, b, stack) => {
+            const result = b.shrn(a.toNumber());
+            logger.debug('SHR', [a, b], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        sar: (nobits, value, stack) => {
+            const _nobits = nobits.toNumber();
+            let valueBase2;
+            if (value.isNeg()) {
+                valueBase2 = value.toTwos(256).toString(2);
+            } else {
+                valueBase2 = value.toString(2).padStart(256, '0');
+            }
+            // remove LSB * _nobits
+            valueBase2 = valueBase2.substring(0, valueBase2.length - _nobits);
+            // add MSB * _nobits
+            valueBase2 = valueBase2[0].repeat(_nobits) + valueBase2;
+            const result = (new BN(valueBase2, 2)).fromTwos(256);
+            logger.debug('SAR', [nobits, value], [result], getCache(), getMemory(), stack);
+            return result;
+        },
+        handlePush: (code, bytecode, position, stack) => {
+            const no = code - 0x60 + 1;
+            const value = toBN(bytecode.slice(position, position + no));
+            logger.debug('PUSH' + no + ' 0x' + value.toString(16).padStart(no, '0'), [value], [], getCache(), getMemory(), stack);
+            stack.push(value);
+            position += no;
+            return {bytecode: bytecode, stack, position};
+        },
+        handleSwap: (code, stack) => {
+            const no = code - 0x90 + 1;
+            if (no >= stack.length) throw new Error(`Invalid SWAP${no} ; stack: ${stack}`);
+            const last = stack.pop();
+            const spliced = stack.splice(stack.length - no, 1, last);
+            logger.debug('SWAP' + no, [], [], getCache(), getMemory(), stack);
+            stack.push(spliced[0]);
+
+            return stack;
+        },
+        handleDup: (code, stack) => {
+            const no = code - 0x80 + 1;
+            if (no > stack.length) throw new Error(`Invalid DUP${no} ; stack: ${stack}`);
+            const value = stack[stack.length - no];
+
+            logger.debug('DUP' + no, [], [], getCache(), getMemory(), stack);
+            stack.push(value);
+            return stack;
+        },
+        jump: (newpos, stack) => {
+            if (!newpos && newpos !== 0) throw new Error(`Invalid JUMP ${newpos}`);
+            newpos = newpos.toNumber();
+            logger.debug('JUMP', [newpos], [], getCache(), getMemory(), stack);
+            return newpos;
+        },
+        jumpi: (newpos, condition, stack) => {
+            logger.debug('JUMPI', [newpos, condition], [], getCache(), getMemory(), stack);
+            newpos = newpos.toNumber();
+            if (condition.toNumber() === 1) return newpos;
+        },
+        jumpdest:(tag, stack) => {
+            logger.debug('JUMPDEST', [tag], [], getCache(), getMemory(), stack);
+        },
+        pop: stack => {
+            stack.pop();
+            logger.debug('POP', [], [], getCache(), getMemory(), stack);
+            return stack;
+        }
+    }
+
+    return api;
+}
+
+const instantiateModule = (bytecode, importObj) => {
+    if (typeof bytecode === 'string') bytecode = hexToUint8Array(bytecode);
+    if (!(bytecode instanceof Uint8Array)) throw new Error('evm - bytecode not Uint8Array');
+    const wmodule = {
+        instance: {
+            exports: {
+                main: calldata => interpreter({bytecode, importObj: importObj.ethereum, calldata, position: 0}),
+                memory: new WebAssembly.Memory({ initial: 2 }),
+            }
+        }
+
+    }
+    return new Promise((resolve, reject) => {
+        resolve(wmodule);
+    });
+}
+
+const interpreter = async ({bytecode, importObj, stack = [], calldata=[], position=0}) => {
+    ({bytecode, stack, position} = await interpretOpcode({bytecode, stack, importObj, position}));
+    if (position > 0) await interpreter({bytecode, importObj, stack, calldata, position});
+}
+
+const interpretOpcode = async ({bytecode, stack, importObj, position}) => {
+    const hexcode = bytecode[position].toString(16).padStart(2, '0');
+    position += 1;
+    const code = parseInt(hexcode, 16);
+    const opcode = opcodes[hexcode];
+
+    if (opcode && importObj[opcode.name]) {
+        const args = [];
+        for (let i = 0; i < opcode.arity; i++) {
+            args.push(stack.pop());
+        }
+
+        if (opcode.name === 'jump') {
+            return {bytecode, stack, position: importObj.jump(...args, stack)};
+        }
+        if (opcode.name === 'jumpi') {
+            return {bytecode, stack, position: importObj.jumpi(...args, stack) || position};
+        }
+        if (opcode.name === 'pop') {
+            return {bytecode, stack: importObj.pop(stack), position};
+        }
+
+        const result = await importObj[opcode.name](...args, stack);
+
+        if (result === '*stop*') return {bytecode, stack, position: 0};
+        if (result) stack.push(toBN(result));
+
+        return {bytecode, stack, position};
+    }
+    else if (0x60 <= code && code < 0x80) return importObj.handlePush(code, bytecode, position, stack);
+    else if (0x80 <= code && code < 0x90) return {bytecode, stack: importObj.handleDup(code, stack), position};
+    else if (0x90 <= code && code < 0xa0) return {bytecode, stack: importObj.handleSwap(code, stack), position};
+
+    throw new Error(`Invalid opcode ${hexcode}; ${typeof hexcode} - ${JSON.stringify(opcode)}`);
+}
+
+const opcodes = {
+    '00': {name: 'stop', arity: 0},
+    '01': {name: 'add', arity: 2},
+    '02': {name: 'mul', arity: 2},
+    '03': {name: 'sub', arity: 2},
+    '04': {name: 'div', arity: 2},
+    '05': {name: 'sdiv', arity: 2},
+    '06': {name: 'mod', arity: 2},
+    '07': {name: 'smod', arity: 2},
+    '08': {name: 'addmod', arity: 3},
+    '09': {name: 'mulmod', arity: 3},
+    '0a': {name: 'exp', arity: 2},
+    '0b': {name: 'signextend', arity: 2},
+
+    '10': {name: 'lt', arity: 2},
+    '11': {name: 'gt', arity: 2},
+    '12': {name: 'slt', arity: 2},
+    '13': {name: 'sgt', arity: 2},
+    '14': {name: 'eq', arity: 2},
+    '15': {name: 'iszero', arity: 1},
+    '16': {name: 'and', arity: 2},
+    '17': {name: 'or', arity: 2},
+    '18': {name: 'xor', arity: 2},
+    '19': {name: 'not', arity: 1},
+    '1a': {name: 'byte', arity: 2},
+    '1b': {name: 'shl', arity: 2},
+    '1c': {name: 'shr', arity: 2},
+    '1d': {name: 'sar', arity: 2},
+
+    '20': {name: 'keccak256', arity: 1},
+
+    '30': {name: 'getAddress', arity: 0},
+    '31': {name: 'getExternalBalance', arity: 1},
+    '32': {name: 'getTxOrigin', arity: 0},
+    '33': {name: 'getCaller', arity: 0},
+    '34': {name: 'getCallValue', arity: 0},
+    '35': {name: 'callDataLoad', arity: 1},
+    '36': {name: 'getCallDataSize', arity: 0},
+    '37': {name: 'callDataCopy', arity: 3},
+    '38': {name: 'getCodeSize', arity: 0},
+    '39': {name: 'codeCopy', arity: 3},
+    '3a': {name: 'getTxGasPrice', arity: 0},
+    '3b': {name: 'getExternalCodeSize', arity: 1},
+    '3c': {name: 'externalCodeCopy', arity: 4},
+    '3d': {name: 'getReturnDataSize', arity: 0},
+    '3e': {name: 'returnDataCopy', arity: 3},
+    '3f': {name: 'getExternalCodeHash', arity: 1},
+
+    '40': {name: 'getBlockHash', arity: 1},
+    '41': {name: 'getBlockCoinbase', arity: 0},
+    '42': {name: 'getBlockTimestamp', arity: 0},
+    '43': {name: 'getBlockNumber', arity: 0},
+    '44': {name: 'getBlockDifficulty', arity: 0},
+    '45': {name: 'getBlockGasLimit', arity: 0},
+    '46': {name: 'getBlockChainId', arity: 0},
+    '47': {name: 'getSelfBalance', arity: 0},
+
+    '50': {name: 'pop', arity: 1},
+    '51': {name: 'loadMemory', arity: 1},
+    '52': {name: 'storeMemory', arity: 2},
+    '53': {name: 'storeMemory8', arity: 2},
+    '54': {name: 'storageLoad', arity: 1},
+    '55': {name: 'storageStore', arity: 2},
+    '56': {name: 'jump', arity: 1},
+    '57': {name: 'jumpi', arity: 2},
+    '58': {name: 'pc', arity: 0},
+    '59': {name: 'getMSize', arity: 0},
+    '5a': {name: 'getGasLeft', arity: 0},
+    '5b': {name: 'jumpdest', arity: 0},
+
+    'a0': {name: 'log0', arity: 2},
+    'a1': {name: 'log1', arity: 3},
+    'a2': {name: 'log2', arity: 4},
+    'a3': {name: 'log3', arity: 5},
+    'a4': {name: 'log4', arity: 6},
+
+    'f0': {name: 'create', arity: 3},
+    'f1': {name: 'call', arity: 7},
+    'f2': {name: 'callCode', arity: 7},
+    'f3': {name: 'return', arity: 2},
+    'f4': {name: 'callDelegate', arity: 6},
+    'f5': {name: 'create2', arity: 3},
+    'fa': {name: 'callStatic', arity: 6},
+    'fd': {name: 'revert', arity: 2},
+    'fe': {name: 'invalid', arity: 0},
+    'ff': {name: 'selfDestruct', arity: 1},
+}
+
+module.exports = {initializeImports, instantiateModule};

--- a/src/evm.js
+++ b/src/evm.js
@@ -3,10 +3,7 @@ const {
     hexToUint8Array,
     toBN,
     BN2uint8arr,
-    uint8ArrayToHex,
 }  = require('./utils.js');
-const {ERROR} = require('./constants');
-const evmasm = require('evmasm');
 
 const initializeImports = (
     vmcore,

--- a/src/ewasm.js
+++ b/src/ewasm.js
@@ -1,6 +1,5 @@
 const BN = require('bn.js');
 const {
-    uint8ArrayToHex,
     newi32,
     instantiateWasm,
     toBN,

--- a/src/ewasm.js
+++ b/src/ewasm.js
@@ -1,312 +1,11 @@
-const { ethers } = require('ethers');
-const { ERROR } = require('./constants');
-const Logger = require('./config');
-const jsvm = require('./jsvm.js');
 const {
-    encodeWithSignature,
-    encode,
-    decode,
-    logu8a,
     uint8ArrayToHex,
-    hexToUint8Array,
     newi32,
-    newi64,
-    randomAddress,
     instantiateWasm,
-    extractAddress,
 }  = require('./utils.js');
-const {
-    cloneContext,
-    cloneLogs,
-} = require('./persistence.js');
 
-const jsvmi = jsvm();
-
-const deploy = (wasmSource, wabi) => async (...args) => {
-    Logger.get('ewasmvm').debug('deploy', ...args);
-    const address = randomAddress();
-    const constructori = await initializeWrap(wasmSource, wabi, address, false);
-    // TODO: constructor args
-    const txInfo = args[args.length - 1];
-    await constructori.main(txInfo);
-    Logger.get('ewasmvm').debug('deployed', address);
-    const instance = await runtime(address, wabi);
-    return instance;
-}
-
-const runtime = (address, wabi) => {
-    Logger.get('ewasmvm').debug('runtime', address);
-    const runtimeCode = jsvmi.persistence.get(address).runtimeCode;
-    return initializeWrap(runtimeCode, wabi, address, true);
-}
-
-const runtimeSim = (wasmSource, wabi, address) => {
-    address = address || '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
-    return initializeWrap(wasmSource, wabi, address, true);
-}
-
-async function initializeWrap (wasmbin, wabi=[], address, atRuntime = false) {
-    wasmbin = typeof wasmbin === 'string' ? hexToUint8Array(wasmbin) : wasmbin;
-    let currentPromise;
-
-    Logger.get('ewasmvm').get('initializeWrap').debug(address);
-
-    opcodelogs = [];
-    opcodeLogger = Logger.spawn('opcodes', Logger.LEVELS.DEBUG, (...args) => {
-        const [name, input, output, cache, memory] = args;
-        const {context, logs, data} = cache;
-        const clonedContext = cloneContext(context);
-        const clonedLogs =  cloneLogs(logs);
-        const currentContext = clonedContext[address] || {};
-        clonedMemory = hexToUint8Array(uint8ArrayToHex(new Uint8Array(memory.buffer)));
-        opcodelogs.push({name, input, output, memory: clonedMemory, logs: clonedLogs, context: clonedContext, contract: currentContext});
-        return;
-    });
-
-    function storeStateChanges (context, logs) {
-        Logger.get('ewasmvm').get('storeStateChanges').debug(Object.keys(context), logs.length);
-        Logger.get('ewasmvm').get('context').debug('storeStateChanges', context);
-        Logger.get('ewasmvm').get('logs').debug('storeStateChanges', logs);
-        jsvmi.persistence.setBulk(context);
-        jsvmi.logs.setBulk(logs);
-    }
-
-    const finishAction = answ => {
-        // TODO: code doesn't have a currentPromise when wasm execution is restarted
-        // same for revert; the promise should not vanish.
-        if (!currentPromise) return; //  throw new Error('No queued promise found.');
-        if (currentPromise.name === 'constructor') {
-            Logger.get('ewasmvm').get('finishAction_constructor').debug(currentPromise.name, answ);
-            currentPromise.cache.context[address].runtimeCode = answ;
-            storeStateChanges(currentPromise.cache.context, currentPromise.cache.logs);
-            currentPromise.resolve(address);
-        } else {
-            const abi = wabi.find(abi => abi.name === currentPromise.name);
-            Logger.get('ewasmvm').get('finishAction').debug(currentPromise.name, answ);
-            const decoded = answ && abi && abi.outputs ? decode(abi.outputs, answ) : answ;
-            storeStateChanges(currentPromise.cache.context, currentPromise.cache.logs);
-            currentPromise.resolve(decoded);
-        }
-        currentPromise = null;
-    }
-    const revertAction = answ => {
-        if (!currentPromise) return; //  throw new Error('No queued promise found.');
-        const error = new Error('Revert: ' + uint8ArrayToHex(answ));
-        Logger.get('ewasmvm').get('revertAction').debug(currentPromise.name, answ);
-        currentPromise.reject(error);
-        currentPromise = null;
-    }
-
-    const getfname = (fabi) => !atRuntime ? 'constructor' : (fabi ? fabi.name : 'main');
-
-    const wrappedMainRaw = (fabi) => (txInfo, existingCache = {}) => new Promise((resolve, reject) => {
-        if (currentPromise) throw new Error('No queue implemented. Come back later.');
-        const fname = getfname(fabi);
-        let minstance;
-        txInfo = {...txInfo};  // TODO immutable
-        txInfo.to = txInfo.to || address;
-
-        Logger.get('ewasmvm').get('tx').debug('wrappedMainRaw--' + fname, txInfo);
-
-        // cache is changed in place, by reference
-        // context[address] = {balance, runtimeCode, storage}  // persistence
-        // data[index] = {gaslimit, to, data, value, result}
-        const cache = { data: {}, context: existingCache.context || {}, logs: existingCache.logs || [] };
-        cache.get = index => cache.data[index];
-        cache.set = (index, obj) => cache.data[index] = obj;
-        cache.getAndCheck = (index, txobj) => {
-            const cachedtx = cache.get(index);
-            const hexdata = lowtx2hex(txobj)
-
-            if (!cachedtx || !cachedtx.result) return;
-            Object.keys(cachedtx).forEach(key => {
-                if (key !== 'result' && comparify(cachedtx[key]) !== comparify(hexdata[key])) throw new Error(`Cache doesn't match data for key ${key}. Cache: ${cachedtx[key]} vs. ${hexdata[key]}`);
-            });
-            return cachedtx;
-        }
-        cache.context[txInfo.from] = jsvmi.persistence.get(txInfo.from);
-        cache.context[txInfo.to] = jsvmi.persistence.get(txInfo.to);
-        // constructor
-        if (!cache.context[txInfo.to].runtimeCode) {
-            cache.context[txInfo.to].runtimeCode = txInfo.data;
-            cache.context[txInfo.to].storage = {};
-        }
-        // needed, otherwise it cycles;
-        cache.context[txInfo.from].empty = false;
-        cache.context[txInfo.to].empty = false;
-
-        const getMemory = () => minstance.exports.memory
-        const getCache = () => {
-            // TODO somehow this gets called after finishAction
-            // need to see where
-            return currentPromise.cache;
-        }
-
-        let internalCallTxObj = {};
-        const internalCallWrap = (index, dataObj, context, logs) => {
-            const newtx = {
-                ...currentPromise.txInfo,
-                ...lowtx2hex(dataObj),
-            }
-
-            currentPromise.parent = true;
-            internalCallTxObj = { index, newtx, context, logs };
-        }
-
-        const internalCallWrapContinue = async () => {
-            const { index, newtx, context, logs } = internalCallTxObj;
-            Logger.get('ewasmvm').get('internalCallWrapContinue').debug(index);
-
-            const wmodule = await runtime(newtx.to, []);
-            let result = {};
-            currentPromise.cache.data[index] = newtx;
-            try {
-                result.data = await wmodule.mainRaw(newtx, {context, logs});  // TODO pass apropriate cache
-                result.success = 1;
-            } catch (e) {
-                result.success = 0;
-            }
-            currentPromise.cache.data[index].result = result;
-            internalCallTxObj = {};
-
-            // restart execution from scratch with updated cache
-            // TODO: get gas left and forward it
-            startExecution(wasmbin, currentPromise.txInfo, currentPromise.cache);
-        }
-
-        let internalResourceCall = {};
-        const asyncResourceWrap = (account) => {
-            internalResourceCall.account = account;
-        }
-        const asyncResourceWrapContinue = async() => {
-            const data = jsvmi.persistence.get(internalResourceCall.account);
-            // We must delete this, to avoid requesting the resource over and over again
-            delete data.empty;
-            currentPromise.cache.context[internalResourceCall.account] = data;
-            Logger.get('ewasmvm').get('asyncResourceWrapContinue').debug(data.account, data.balance, Object.keys(currentPromise.cache.context));
-            internalResourceCall = {};
-
-            // restart execution from scratch with updated cache
-            startExecution(wasmbin, currentPromise.txInfo, currentPromise.cache);
-        }
-
-        const startExecution = (_wasmbin, txInfo, cache) => {
-            currentPromise = {
-                resolve,
-                reject,
-                name: fname,
-                txInfo,
-                gas: {limit: txInfo.gasLimit, price: txInfo.gasPrice, used: newi64(0)},
-                data: typeof txInfo.data === 'string' ? hexToUint8Array(txInfo.data) : txInfo.data,
-                cache,
-            };
-            currentPromise.txInfo.data = currentPromise.data;
-            currentPromise.txInfo.to = address;
-
-            if (!currentPromise.cache.context[txInfo.to]) {
-                currentPromise.cache.context[txInfo.to] = jsvmi.persistence.get(txInfo.to);
-                currentPromise.cache.context[txInfo.to].empty = false;
-            }
-
-            Logger.get('ewasmvm').get('tx').debug('startExecution', currentPromise.txInfo);
-            Logger.get('ewasmvm').debug('startExecution', Object.keys(currentPromise.cache.context));
-
-            const importObj = initializeEthImports(
-                currentPromise.txInfo,
-                internalCallWrap,
-                asyncResourceWrap,
-                getMemory,
-                getCache,
-                finishAction,
-                revertAction,
-                opcodeLogger,
-            );
-
-            instantiateWasm(_wasmbin, importObj).then(wmodule => {
-                minstance = wmodule.instance;
-                opcodeLogger.debug('--', [], [], getCache(), getMemory());
-                try {
-                    minstance.exports.main();
-                } catch (e) {
-                    console.log(e.message);
-
-                    switch(e.message) {
-                        case ERROR.ASYNC_CALL:
-                            // wasm execution stopped, so it can be restarted
-                            // TODO - restart needs to wait until call result
-                            internalCallWrapContinue();
-                            break;
-                        case ERROR.ASYNC_RESOURCE:
-                            asyncResourceWrapContinue();
-                            break;
-                        default:
-                            throw e;
-                    }
-                }
-            });
-        }
-
-        startExecution(wasmbin, txInfo, cache);
-    });
-
-    const wrappedMain = (signature, fabi) => (...input) => {
-        const fname = getfname(fabi);
-        const args = input.slice(0, input.length - 1);
-        const txInfo = input[input.length - 1];
-        txInfo.origin = txInfo.origin || txInfo.from;
-        txInfo.value = txInfo.value || '0x00';
-
-
-        const calldataTypes = (wabi.find(abi => abi.name === fname) || {}).inputs;
-        const calldata = signature ? encodeWithSignature(signature, calldataTypes, args) : encode(calldataTypes, args);
-        txInfo.data = calldata;
-
-        if (!signature && !fabi && txInfo.data.length === 0) {
-            // constructor
-            txInfo.data = wasmbin;
-        }
-
-        return wrappedMainRaw(fabi) (txInfo);
-    }
-
-    const wrappedInstance = {
-        main: wrappedMain(),
-        mainRaw: wrappedMainRaw(),
-        address,
-        abi: wabi,
-        bin: wasmbin,
-        logs: opcodelogs,
-    }
-
-    wabi.forEach(method => {
-        if (method.name === 'constructor') return;
-        if (method.type === 'fallback') {
-            wrappedInstance[method.name] = wrappedMain();
-        } else {
-            const signature = ethers.utils.id(signatureFull(method)).substring(0, 10);
-            wrappedInstance[method.name] = wrappedMain(signature, method);
-        }
-    })
-
-    return wrappedInstance;
-}
-
-const signatureFull = fabi => {
-    return `${fabi.name}(${fabi.inputs.map(inp => inp.type).join(',')})`;
-}
-
-function lowtx2hex(dataObj) {
-    return {
-        ...dataObj,
-        to: extractAddress(dataObj.to),
-        value: uint8ArrayToHex(dataObj.value),
-        from: extractAddress(dataObj.from),
-        origin: extractAddress(dataObj.origin),
-        // gasLimit, gasPrice? transform to hex
-    }
-}
-
-const initializeEthImports = (
+const initializeImports = (
+    vmcore,
     txObj,
     internalCallWrap,
     asyncResourceWrap,
@@ -316,7 +15,7 @@ const initializeEthImports = (
     revertAction,
     logger,
 ) => {
-    const jsvm_env = jsvmi.call(txObj, internalCallWrap, asyncResourceWrap, getMemory, getCache);
+    const jsvm_env = vmcore.call(txObj, internalCallWrap, asyncResourceWrap, getMemory, getCache);
     return {
         // i32ptr is u128
         // 33 methods
@@ -633,6 +332,8 @@ const initializeEthImports = (
     }
 }
 
+const instantiateModule = instantiateWasm;
+
 function readAddress(jsvm_env, addressOffset) {
     const address = jsvm_env.loadMemory(addressOffset);
     // rigth -> left shift
@@ -641,15 +342,5 @@ function readAddress(jsvm_env, addressOffset) {
     return lsAddress;
 }
 
-function comparify(value) {
-    if (value instanceof Uint8Array) return uint8ArrayToHex(value);
-    if (value instanceof Object) return JSON.stringify(value);
-    return value;
-}
 
-const getBlock = tag => jsvmi.blocks.get(tag);
-const getLogs = () => jsvmi.logs;
-// dev purposes:
-const getPersistence = () => jsvmi.persistence;
-
-module.exports = {deploy, runtime, runtimeSim, getBlock, getLogs, getPersistence};
+module.exports = {initializeImports, instantiateModule};

--- a/src/ewasm.js
+++ b/src/ewasm.js
@@ -55,13 +55,12 @@ const initializeImports = (
                 // outputLength_i32,
             ) {
                 const address = readAddress(jsvm_env, addressOffset_i32ptr_address);
-
-                // return newi32(0);
+                const value = jsvm_env.loadMemory(valueOffset_i32ptr_u128, 32);
 
                 const result = jsvm_env.call(
                     gas_limit_i64,
                     address,
-                    valueOffset_i32ptr_u128,
+                    value,
                     dataOffset_i32ptr_bytes,
                     dataLength_i32,
                     // outputOffset_i32ptr_bytes,
@@ -81,6 +80,11 @@ const initializeImports = (
                 logger.debug('getCallDataSize', [], [result], getCache(), getMemory());
                 return result;
             },
+            callDataLoad: function(dataOffset) {
+                const result = jsvm_env.callDataLoad(dataOffset);
+                logger.debug('callDataLoad', [dataOffset], [result], getCache(), getMemory());
+                return result;
+            },
             // result i32 Returns 0 on success, 1 on failure and 2 on revert
             callCode: function (
                 gas_limit_i64,
@@ -90,10 +94,11 @@ const initializeImports = (
                 dataLength_i32,
             ) {
                 const address = readAddress(jsvm_env, addressOffset_i32ptr_address);
+                const value = jsvm_env.loadMemory(valueOffset_i32ptr_u128, 32);
                 const result = jsvm_env.callCode(
                     gas_limit_i64,
                     address,
-                    valueOffset_i32ptr_u128,
+                    value,
                     dataOffset_i32ptr_bytes,
                     dataLength_i32,
                     // outputOffset_i32ptr_bytes,
@@ -235,7 +240,7 @@ const initializeImports = (
             getExternalCodeSize: function (addressOffset_i32ptr_address) {
                 const address = readAddress(jsvm_env, addressOffset_i32ptr_address);
                 const result = jsvm_env.getExternalCodeSize(address);
-                logger.debug('getBlockDifficulty', [addressOffset_i32ptr_address], [result], getCache(), getMemory());
+                logger.debug('getExternalCodeSize', [addressOffset_i32ptr_address], [result], getCache(), getMemory());
                 return result;
             },
             // result gasLeft i64

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const {
 
 const _vmcore = require('./jsvm.js');
 const _ewasmjsvm = require('./ewasm.js');
-// const _evm = require('./evm.js');
+const _evm = require('./evm.js');
 const _instance = require('./instance');
 const utils = require('./utils.js');
 
@@ -18,16 +18,16 @@ const ewasmjsvm = () => _instance({
     initializeImports: _ewasmjsvm.initializeImports,
     instantiateModule: _ewasmjsvm.instantiateModule,
 });
-// const evmjs = () => _instance({
-//     vmname: 'evmjs',
-//     vmcore: vmcore(),
-//     initializeImports: _evm.initializeImports,
-//     instantiateModule: _evm.instantiateModule,
-// });
+const evmjs = () => _instance({
+    vmname: 'evmjs',
+    vmcore: vmcore(),
+    initializeImports: _evm.initializeImports,
+    instantiateModule: _evm.instantiateModule,
+});
 
 module.exports = {
     vmcore,
     ewasmjsvm,
-    // evmjs,
+    evmjs,
     utils,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,33 @@
+const {Logger} = require('./config');
+const {
+    persistence,
+    blocks,
+    logs,
+} = require('./persistence.js');
 
-const jsvm = require('./jsvm.js');
-const ewasmjsvm = require('./ewasm.js');
+const _vmcore = require('./jsvm.js');
+const _ewasmjsvm = require('./ewasm.js');
+// const _evm = require('./evm.js');
+const _instance = require('./instance');
 const utils = require('./utils.js');
 
+const vmcore = () => _vmcore(persistence, blocks, logs, Logger);
+const ewasmjsvm = () => _instance({
+    vmname: 'ewasmjsvm',
+    vmcore: vmcore(),
+    initializeImports: _ewasmjsvm.initializeImports,
+    instantiateModule: _ewasmjsvm.instantiateModule,
+});
+// const evmjs = () => _instance({
+//     vmname: 'evmjs',
+//     vmcore: vmcore(),
+//     initializeImports: _evm.initializeImports,
+//     instantiateModule: _evm.instantiateModule,
+// });
+
 module.exports = {
-    jsvm,
+    vmcore,
     ewasmjsvm,
+    // evmjs,
     utils,
 }

--- a/src/instance.js
+++ b/src/instance.js
@@ -7,7 +7,6 @@ const {
     decode,
     uint8ArrayToHex,
     hexToUint8Array,
-    newi64,
     randomAddress,
     extractAddress,
     BN2uint8arr,

--- a/src/instance.js
+++ b/src/instance.js
@@ -342,7 +342,7 @@ function instance ({
             currentPromise.minstance = wmodule.instance;
             ologger.debug('--', [], [], getCache(), getMemory());
             try {
-                wmodule.instance.exports.main();
+                await wmodule.instance.exports.main();
             } catch (e) {
                 console.log(e.message);
 

--- a/src/instance.js
+++ b/src/instance.js
@@ -1,0 +1,372 @@
+const { ethers } = require('ethers');
+const { ERROR } = require('./constants');
+const {Logger, logg} = require('./config');
+const {
+    encodeWithSignature,
+    encode,
+    decode,
+    uint8ArrayToHex,
+    hexToUint8Array,
+    newi64,
+    randomAddress,
+    extractAddress,
+}  = require('./utils.js');
+const {
+    cloneContext,
+    cloneLogs,
+} = require('./persistence.js');
+
+function instance ({
+    vmname,
+    vmcore,
+    initializeImports,
+    instantiateModule,
+}) {
+    // persistence = {accounts, logs, blocks}
+    // Internal logger
+    const logger = Logger.get(vmname)
+    const ilogger = logger.spawn('internal');
+
+    const deploy = (bytecode, wabi) => async (...args) => {
+        ilogger.debug('deploy', ...args);
+        const address = randomAddress();
+        const constructori = await initializeWrap(bytecode, wabi, address, false);
+        // TODO: constructor args
+        const txInfo = args[args.length - 1];
+        await constructori.main(txInfo);
+        ilogger.debug('deployed', address);
+        const instance = await runtime(address, wabi);
+        return instance;
+    }
+
+    const runtime = (address, wabi) => {
+        ilogger.debug('runtime', address);
+        const runtimeCode = vmcore.persistence.accounts.get(address).runtimeCode;
+        return initializeWrap(runtimeCode, wabi, address, true);
+    }
+
+    const runtimeSim = (bytecode, wabi, address) => {
+        address = address || '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+        return initializeWrap(bytecode, wabi, address, true);
+    }
+
+    async function initializeWrap (bytecode, wabi=[], address, atRuntime = false) {
+        bytecode = typeof bytecode === 'string' ? hexToUint8Array(bytecode) : bytecode;
+        const opcodelogs = [];  // {logs: [], internal: {indexopcode: logs:[]}}
+
+        ilogger.get('initializeWrap').debug(address);
+
+        const getfname = (fabi) => !atRuntime ? 'constructor' : (fabi ? fabi.name : 'main');
+        const _finishAction = finishAction(ilogger, vmcore.persistence, address, wabi);
+        const _revertAction = revertAction(ilogger);
+        const _ologger = ologger(log => {
+            opcodelogs.push(log);
+        }, address);
+        const _startExecution = startExecution({
+            vmcore,
+            ilogger,
+            ologger: _ologger,
+            initializeImports,
+            instantiateModule,
+            finishAction: _finishAction,
+            revertAction: _revertAction,
+        });
+        const _wrappedMainRaw = wrappedMainRaw({ilogger, persistence: vmcore.persistence, _startExecution, address, bytecode, getfname});
+        const _wrappedMain = wrappedMain(_wrappedMainRaw, getfname, wabi, bytecode);
+
+        const wrappedInstance = {
+            main: _wrappedMain(),
+            mainRaw: _wrappedMainRaw(),
+            address,
+            abi: wabi,
+            bin: bytecode,
+            logs: opcodelogs,
+        }
+
+        wabi.forEach(method => {
+            if (method.name === 'constructor') return;
+            if (method.type === 'fallback') {
+                wrappedInstance[method.name] = _wrappedMain();
+            } else {
+                const signature = ethers.utils.id(signatureFull(method)).substring(0, 10);
+                wrappedInstance[method.name] = _wrappedMain(signature, method);
+            }
+        })
+
+        return wrappedInstance;
+    }
+
+    const _storeStateChanges = storeStateChanges(ilogger, vmcore.persistence);
+
+    const finishAction = (ilogger, persistence, address, wabi) => currentPromise => answ => {
+        if (!currentPromise)  throw new Error('No queued promise found.');
+        let result;
+        if (currentPromise.name === 'constructor') {
+            ilogger.get('finishAction_constructor').debug(currentPromise.name, answ);
+            currentPromise.cache.context[address].runtimeCode = answ;
+            result = address;
+        } else {
+            const abi = wabi.find(abi => abi.name === currentPromise.name);
+            ilogger.get('finishAction').debug(currentPromise.name, answ);
+            result = answ && abi && abi.outputs ? decode(abi.outputs, answ) : answ;
+        }
+        _storeStateChanges({accounts: currentPromise.cache.context, logs: currentPromise.cache.logs});
+        currentPromise.resolve(result);
+        currentPromise = null;
+    }
+
+    const revertAction = (ilogger) => currentPromise => answ => {
+        if (!currentPromise) throw new Error('No queued promise found.');
+        const error = new Error('Revert: ' + uint8ArrayToHex(answ));
+        ilogger.get('revertAction').debug(currentPromise.name, answ);
+        currentPromise.reject(error);
+        currentPromise = null;
+    }
+
+    const buildCache = (existingCache) => {
+        // cache is changed in place, by reference
+        // context[address] = {balance, runtimeCode, storage}  // persistence
+        // data[index] = {gaslimit, to, data, value, result}
+        const cache = { data: {}, context: existingCache.context || {}, logs: existingCache.logs || [] };
+        cache.get = index => cache.data[index];
+        cache.set = (index, obj) => cache.data[index] = obj;
+        cache.getAndCheck = (index, txobj) => {
+            const cachedtx = cache.get(index);
+            const hexdata = lowtx2hex(txobj)
+
+            if (!cachedtx || !cachedtx.result) return;
+            Object.keys(cachedtx).forEach(key => {
+                if (key !== 'result' && comparify(cachedtx[key]) !== comparify(hexdata[key])) throw new Error(`Cache doesn't match data for key ${key}. Cache: ${cachedtx[key]} vs. ${hexdata[key]}`);
+            });
+            return cachedtx;
+        }
+        return cache;
+    }
+
+    const wrappedMainRaw = ({ilogger, persistence, _startExecution, address, bytecode, getfname}) => (fabi) => (txInfo, existingCache = {}) => new Promise((resolve, reject) => {
+        txInfo = {...txInfo};  // TODO immutable
+        txInfo.to = txInfo.to || address;
+
+        const cache = buildCache(existingCache);
+        cache.context[txInfo.from] = persistence.accounts.get(txInfo.from);
+        cache.context[txInfo.to] = persistence.accounts.get(txInfo.to);
+        // constructor TODO: check if constructor
+        if (!cache.context[txInfo.to].runtimeCode) {
+            cache.context[txInfo.to].runtimeCode = txInfo.data;
+            cache.context[txInfo.to].storage = {};
+        }
+        // needed, otherwise it cycles;
+        cache.context[txInfo.from].empty = false;
+        cache.context[txInfo.to].empty = false;
+
+        let currentPromise = {
+            resolve, reject,
+            name: getfname(fabi),
+            txInfo,
+            gas: {limit: txInfo.gasLimit, price: txInfo.gasPrice, used: newi64(0)},
+            data: typeof txInfo.data === 'string' ? hexToUint8Array(txInfo.data) : txInfo.data,
+            cache
+        };
+        currentPromise.txInfo.data = currentPromise.data;
+        currentPromise.txInfo.to = address;
+        if (!currentPromise.cache.context[txInfo.to]) {
+            currentPromise.cache.context[txInfo.to] = persistence.accounts.get(txInfo.to);
+            currentPromise.cache.context[txInfo.to].empty = false;
+        }
+        const __startExecution = () => _startExecution({
+            currentPromise,
+            bytecode,
+            getCache,
+            txInfo,
+            internalCallWrap,
+            internalCallWrapContinue,
+            asyncResourceWrap,
+            asyncResourceWrapContinue,
+        });
+
+        ilogger.get('tx').debug('wrappedMainRaw--' + currentPromise.name, txInfo);
+
+        const getCache = () => {
+            // TODO somehow this gets called after finishAction
+            // need to see where
+            return currentPromise.cache;
+        }
+
+        const internalCallWrap = (index, dataObj, context, logs) => {
+            const newtx = {...currentPromise.txInfo, ...lowtx2hex(dataObj)}
+            currentPromise.parent = true;
+            currentPromise.interruptTxObj = { index, newtx, context, logs };
+        }
+
+        const internalCallWrapContinue = async () => {
+            const { index, newtx, context, logs } = currentPromise.interruptTxObj;
+            ilogger.get('internalCallWrapContinue').debug(index);
+
+            const wmodule = await runtime(newtx.to, []);
+            let result = {};
+            currentPromise.cache.data[index] = newtx;
+            try {
+                result.data = await wmodule.mainRaw(newtx, {context, logs});
+                result.success = 1;
+            } catch (e) {
+                result.success = 0;
+            }
+            currentPromise.cache.data[index].result = result;
+            currentPromise.interruptTxObj = {};
+
+            // restart execution from scratch with updated cache
+            // TODO: get gas left and forward it
+            __startExecution();
+        }
+
+        const asyncResourceWrap = (account) => {
+            currentPromise.interruptResourceObj = {account};
+        }
+
+        const asyncResourceWrapContinue = async() => {
+            const data = persistence.accounts.get(currentPromise.interruptResourceObj.account);
+            // We must delete this, to avoid requesting the resource over and over again
+            delete data.empty;
+            currentPromise.cache.context[currentPromise.interruptResourceObj.account] = data;
+            ilogger.get('asyncResourceWrapContinue').debug(data.account, data.balance, Object.keys(currentPromise.cache.context));
+            currentPromise.interruptResourceObj = {};
+
+            // restart execution from scratch with updated cache
+            __startExecution();
+        }
+
+        __startExecution();
+    });
+
+    const wrappedMain = (_wrappedMainRaw, getfname, wabi, bytecode) => (signature, fabi) => (...input) => {
+        const fname = getfname(fabi);
+        const args = input.slice(0, input.length - 1);
+        const txInfo = input[input.length - 1];
+        txInfo.origin = txInfo.origin || txInfo.from;
+        txInfo.value = txInfo.value || '0x00';
+
+        const calldataTypes = (wabi.find(abi => abi.name === fname) || {}).inputs;
+        const calldata = signature ? encodeWithSignature(signature, calldataTypes, args) : encode(calldataTypes, args);
+        txInfo.data = calldata;
+
+        if (!signature && !fabi && txInfo.data.length === 0) {
+            // constructor
+            txInfo.data = bytecode;
+        }
+        return _wrappedMainRaw(fabi) (txInfo);
+    }
+
+    const startExecution = ({
+        vmcore,
+        ilogger,
+        ologger,
+        initializeImports,
+        instantiateModule,
+        finishAction,
+        revertAction,
+    }) => ({
+        currentPromise,
+        bytecode,
+        getCache,
+        internalCallWrap,
+        internalCallWrapContinue,
+        asyncResourceWrap,
+        asyncResourceWrapContinue,
+    }) => {
+
+        ilogger.get('tx').debug('startExecution', currentPromise.txInfo);
+        ilogger.debug('startExecution', Object.keys(currentPromise.cache.context));
+
+        const getMemory = () => currentPromise.minstance.exports.memory
+
+        const importObj = initializeImports(
+            vmcore,
+            currentPromise.txInfo,
+            internalCallWrap,
+            asyncResourceWrap,
+            getMemory,
+            getCache,
+            finishAction(currentPromise),
+            revertAction(currentPromise),
+            ologger,
+        );
+
+        instantiateModule(bytecode, importObj).then(wmodule => {
+            currentPromise.minstance = wmodule.instance;
+            ologger.debug('--', [], [], getCache(), getMemory());
+            try {
+                wmodule.instance.exports.main();
+            } catch (e) {
+                console.log(e.message);
+
+                switch(e.message) {
+                    case ERROR.ASYNC_CALL:
+                        // wasm execution stopped, so it can be restarted
+                        // TODO - restart needs to wait until call result
+                        internalCallWrapContinue();
+                        break;
+                    case ERROR.ASYNC_RESOURCE:
+                        asyncResourceWrapContinue();
+                        break;
+                    default:
+                        throw e;
+                }
+            }
+        });
+    }
+
+
+    const vmapi = {
+        deploy,
+        runtime,
+        runtimeSim,
+        getBlock: tag => vmcore.persistence.blocks.get(tag),
+        getLogs: () => vmcore.persistence.logs,
+        // dev purposes
+        getPersistence: () => vmcore.persistence.accounts,
+    }
+
+    return vmapi;
+}
+
+const signatureFull = fabi => {
+    return `${fabi.name}(${fabi.inputs.map(inp => inp.type).join(',')})`;
+}
+function lowtx2hex(dataObj) {
+    return {
+        ...dataObj,
+        to: extractAddress(dataObj.to),
+        value: uint8ArrayToHex(dataObj.value),
+        from: extractAddress(dataObj.from),
+        origin: extractAddress(dataObj.origin),
+        // gasLimit, gasPrice? transform to hex
+    }
+}
+
+const storeStateChanges = (ilogger, persistence) => (context) => {
+    ilogger.get('context').debug('storeStateChanges', context.accounts);
+    ilogger.get('logs').debug('storeStateChanges', context.logs);
+    persistence.accounts.setBulk(context.accounts);
+    persistence.logs.setBulk(context.logs);
+}
+
+const ologger = (callback, address) => logg('opcodes', Logger.LEVELS.DEBUG, (...args) => {
+    const [name, input, output, cache, memory] = args;
+    const {context, logs, data} = cache;
+    const clonedContext = cloneContext(context);
+    const clonedLogs =  cloneLogs(logs);
+    const currentContext = clonedContext[address] || {};
+    clonedMemory = hexToUint8Array(uint8ArrayToHex(new Uint8Array(memory.buffer)));
+    const log = {name, input, output, memory: clonedMemory, logs: clonedLogs, context: clonedContext, contract: currentContext};
+    callback(log);
+    // we return nothing, because we don't print anything;
+    return;
+});
+
+function comparify(value) {
+    if (value instanceof Uint8Array) return uint8ArrayToHex(value);
+    if (value instanceof Object) return JSON.stringify(value);
+    return value;
+}
+
+module.exports = instance;

--- a/src/jsvm.js
+++ b/src/jsvm.js
@@ -1,9 +1,5 @@
 const { ERROR } = require('./constants');
-const Logger = require('./config');
 const {
-    persistence: initPersistence,
-    blocks: initBlocks,
-    logs: initLogs,
     cloneContext,
     cloneLogs,
     cloneStorage,
@@ -18,8 +14,7 @@ const {
     toBN,
 }  = require('./utils.js');
 
-function jsvm() {
-
+function jsvm(initPersistence, initBlocks, initLogs, Logger) {
     const persistence = initPersistence();
     const blocks = initBlocks();
     const chainlogs = initLogs();
@@ -575,12 +570,13 @@ function jsvm() {
         return vmapi;
     }
 
-    return {
-        persistence,
+    const wrappersist = {
+        accounts: persistence,
         blocks,
         logs: chainlogs,
-        call,
     }
+
+    return { persistence: wrappersist, call }
 
 }
 

--- a/src/jsvm.js
+++ b/src/jsvm.js
@@ -216,7 +216,9 @@ function jsvm(initPersistence, initBlocks, initLogs, Logger) {
                 },
                 callDataLoad: function(dataOffset) {
                     dataOffset = dataOffset.toNumber();
-                    return txObj.data.slice(dataOffset, dataOffset + 32);
+                    const data = txObj.data.slice(dataOffset, dataOffset + 32);
+                    const endfill = [...new Array(32 - data.length).keys()].map(v => 0);
+                    return new Uint8Array([...data].concat(endfill));
                 },
                 // result i32 Returns 0 on success, 1 on failure and 2 on revert
                 call: function (

--- a/src/jsvm.js
+++ b/src/jsvm.js
@@ -72,7 +72,7 @@ function jsvm(initPersistence, initBlocks, initLogs, Logger) {
 
         let gas = {
             limit: toBN(txObj.gasLimit || 4000000),
-            price: txObj.gasPrice || toBN(1),
+            price: toBN(txObj.gasPrice || 1),
             used: toBN(0),
         }
         const getGas = () => gas;
@@ -411,7 +411,6 @@ function jsvm(initPersistence, initBlocks, initLogs, Logger) {
                     Logger.get('jsvm').get('callStatic').debug(address, dataOffset, dataLength);
 
                     const data = loadMemory(dataOffset, dataLength);
-
                     const cache = getCache();
                     const currentData = {
                         gasLimit: gas_limit_i64,

--- a/src/jsvm.js
+++ b/src/jsvm.js
@@ -28,9 +28,10 @@ function jsvm() {
         Logger.get('jsvm').get('transferValue').debug(from, to, value, typeof value);
         const parsedValue = toBN(value);
         const fromBalance = persistenceApi.get(from).balance;
+        const toBalance = persistenceApi.get(to).balance;
+        Logger.get('jsvm').get('transferValue').debug('---', fromBalance, fromBalance.toNumber(), toBalance.toNumber(), parsedValue.toNumber());
         if (fromBalance.lt(parsedValue)) throw new Error('Not enough balance.');
 
-        const toBalance = persistenceApi.get(to).balance;
         persistenceApi.updateBalance(to, toBalance.add(parsedValue));
         persistenceApi.updateBalance(from, fromBalance.sub(parsedValue));
     }

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -123,14 +123,18 @@ const cloneStorage = storage => {
     return clonedStorage;
 }
 
+const cloneContract = obj => {
+    return {
+        ...obj,
+        balance: obj.balance.clone(),
+        storage: cloneStorage(obj.storage),
+    }
+}
+
 const cloneContext = (context = {}) => {
     const newcontext = {};
     Object.keys(context).forEach(addr => {
-        newcontext[addr] = {
-            ...context[addr],
-            balance: context[addr].balance.clone(),
-            storage: cloneStorage(context[addr].storage),
-        }
+        newcontext[addr] = cloneContract(context[addr]);
     });
     return newcontext;
 }
@@ -141,4 +145,4 @@ const cloneLog = log => {
 }
 const cloneLogs = logs => logs.map(cloneLog);
 
-module.exports = { persistence: persistenceMock, blocks, logs, cloneContext, cloneLogs };
+module.exports = { persistence: persistenceMock, blocks, logs, cloneContext, cloneLogs, cloneStorage, cloneContract };

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -6,7 +6,7 @@ const persistenceMock = (accounts = {}) => {
     // runtimeCode null - address not set / selfdestructed
     // runtimeCode.length === 0 - address set, not contract
 
-    const get = address => accounts[address] || {...emptyAccount(address), empty: true }
+    const get = address => cloneContract(accounts[address] || {...emptyAccount(address), empty: true });
 
     const set = ({ address, runtimeCode, storage, balance = 0, removed }) => {
         // pathToWasm ?
@@ -41,7 +41,7 @@ const persistenceMock = (accounts = {}) => {
 
     const setBulk = (accounts = {}) => {
         Object.keys(accounts).forEach(addr => {
-            set(accounts[addr]);
+            set(cloneContract(accounts[addr]));
         })
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,7 +15,10 @@ const hexToUint8Array = hexString => ethers.utils.arrayify('0x' + evenHex(strip0
 
 const uint8ArrayToHex = uint8arr => ethers.utils.hexlify(uint8arr);
 
-const decode = (types, uint8arr) => ethers.utils.defaultAbiCoder.decode(types, uint8ArrayToHex(uint8arr));
+const decode = (types, uint8arr) => {
+    const decoded = ethers.utils.defaultAbiCoder.decode(types, uint8ArrayToHex(uint8arr));
+    return {...decoded};
+}
 
 const encode = (types, args) => {
     const encoded = ethers.utils.defaultAbiCoder.encode(types, args);

--- a/src/utils.js
+++ b/src/utils.js
@@ -56,7 +56,7 @@ if (isNode) {
     newi64 = value => new WebAssembly.Global({ value: 'i64', mutable: true }, value.toString());
 }
 
-let instantiateWasm = async (wasmbin, importObj) => {
+let instantiateWasm = async (wasmbin, importObj={}) => {
     if (isNode) {
         const wmodule = new WebAssembly.Module(wasmbin);
         const instance = new WebAssembly.Instance(wmodule, importObj);
@@ -77,10 +77,16 @@ const isHexWasm = source => source.substring(0, 8) === '0061736d'
 // [ 0, 97, 115, 109 ]
 const isBinWasm = uint8Array => uint8Array[0] === 0 && uint8Array[1] === 97 && uint8Array[2] === 115 && uint8Array[3] === 109;
 
+const uint8arrToBN = uint8arr => new BN(strip0x(uint8ArrayToHex(uint8arr)), 16);
+const BN2uint8arr = n => {
+    const res = n.toString(16).padStart(64, '0');
+    return hexToUint8Array(res);
+}
 const toBN = n => {
     if (typeof n === 'string' && n.substring(0, 2) === '0x') {
         return new BN(n.substring(2), 16);
     }
+    if (n instanceof Uint8Array) return uint8arrToBN(n);
     if (BN.isBN(n)) return n;
     return new BN(n);
 }
@@ -105,5 +111,6 @@ module.exports = {
     randomAddress,
     extractAddress,
     toBN,
+    BN2uint8arr,
     clone,
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -88,6 +88,7 @@ const toBN = n => {
     }
     if (n instanceof Uint8Array) return uint8arrToBN(n);
     if (BN.isBN(n)) return n;
+    if (typeof n === 'bigint') return new BN(n.toString());
     return new BN(n);
 }
 

--- a/tests/contracts/c10.yul
+++ b/tests/contracts/c10.yul
@@ -6,18 +6,18 @@
  *******************************************************/
 
 
-object "c10_56" {
+object "c10_63" {
     code {
         mstore(64, memoryguard(128))
         if callvalue() { revert(0, 0) }
 
-        constructor_c10_56()
+        constructor_c10_63()
 
-        codecopy(0, dataoffset("c10_56_deployed"), datasize("c10_56_deployed"))
+        codecopy(0, dataoffset("c10_63_deployed"), datasize("c10_63_deployed"))
 
-        return(0, datasize("c10_56_deployed"))
+        return(0, datasize("c10_63_deployed"))
 
-        function constructor_c10_56() {
+        function constructor_c10_63() {
 
             let expr_3 := 0x05
             update_storage_value_offset_0t_rational_5_by_1_to_t_uint256(0x00, expr_3)
@@ -47,7 +47,7 @@ object "c10_56" {
         }
 
     }
-    object "c10_56_deployed" {
+    object "c10_63_deployed" {
         code {
             mstore(64, memoryguard(128))
 
@@ -56,23 +56,23 @@ object "c10_56" {
                 let selector := shift_right_224_unsigned(calldataload(0))
                 switch selector
 
-                case 0x388ccbd3
-                {
-                    // addvalue_revert(uint256)
-
-                    let param_0 :=  abi_decode_tuple_t_uint256(4, calldatasize())
-                    let ret_0 :=  fun_addvalue_revert_55(param_0)
-                    let memPos := allocateMemory(0)
-                    let memEnd := abi_encode_tuple_t_uint256__to_t_uint256__fromStack(memPos , ret_0)
-                    return(memPos, sub(memEnd, memPos))
-                }
-
                 case 0x3fa4f245
                 {
                     // value()
                     if callvalue() { revert(0, 0) }
                     abi_decode_tuple_(4, calldatasize())
                     let ret_0 :=  getter_fun_value_4()
+                    let memPos := allocateMemory(0)
+                    let memEnd := abi_encode_tuple_t_uint256__to_t_uint256__fromStack(memPos , ret_0)
+                    return(memPos, sub(memEnd, memPos))
+                }
+
+                case 0x42d7c99e
+                {
+                    // _revert()
+
+                    abi_decode_tuple_(4, calldatasize())
+                    let ret_0 :=  fun__revert_62()
                     let memPos := allocateMemory(0)
                     let memEnd := abi_encode_tuple_t_uint256__to_t_uint256__fromStack(memPos , ret_0)
                     return(memPos, sub(memEnd, memPos))
@@ -226,12 +226,31 @@ object "c10_56" {
                 cleaned := value
             }
 
+            function convert_t_rational_10_by_1_to_t_uint256(value) -> converted {
+                converted := cleanup_t_uint256(value)
+            }
+
             function extract_from_storage_value_dynamicsplit_t_uint256(slot_value, offset) -> value {
                 value := cleanup_from_storage_split_t_uint256(shift_right_unsigned_dynamic(mul(offset, 8), slot_value))
             }
 
             function extract_from_storage_value_offset_0t_uint256(slot_value) -> value {
                 value := cleanup_from_storage_t_uint256(shift_right_0_unsigned(slot_value))
+            }
+
+            function fun__revert_62() -> vloc__50 {
+                let zero_value_for_type_t_uint256_10 := zero_value_for_split_t_uint256()
+                vloc__50 := zero_value_for_type_t_uint256_10
+
+                let _11 := read_from_storage_offset_0_t_uint256(0x00)
+                let expr_53 := _11
+                let expr_54 := 0x0a
+                let expr_55 := checked_add_t_uint256(expr_53, convert_t_rational_10_by_1_to_t_uint256(expr_54))
+
+                update_storage_value_offset_0t_uint256_to_t_uint256(0x00, expr_55)
+                let expr_56 := expr_55
+                revert(0, 0)
+
             }
 
             function fun_addvalue_47(vloc__value_30) -> vloc__33 {
@@ -253,12 +272,6 @@ object "c10_56" {
                 let expr_44 := _9
                 vloc__33 := expr_44
                 leave
-
-            }
-
-            function fun_addvalue_revert_55(vloc__value_49) -> vloc__52 {
-                let zero_value_for_type_t_uint256_10 := zero_value_for_split_t_uint256()
-                vloc__52 := zero_value_for_type_t_uint256_10
 
             }
 

--- a/tests/contracts/c12.yul
+++ b/tests/contracts/c12.yul
@@ -6,23 +6,23 @@
  *******************************************************/
 
 
-object "c12_89" {
+object "c12_92" {
     code {
         mstore(64, memoryguard(128))
         if callvalue() { revert(0, 0) }
 
-        constructor_c12_89()
+        constructor_c12_92()
 
-        codecopy(0, dataoffset("c12_89_deployed"), datasize("c12_89_deployed"))
+        codecopy(0, dataoffset("c12_92_deployed"), datasize("c12_92_deployed"))
 
-        return(0, datasize("c12_89_deployed"))
+        return(0, datasize("c12_92_deployed"))
 
-        function constructor_c12_89() {
+        function constructor_c12_92() {
 
         }
 
     }
-    object "c12_89_deployed" {
+    object "c12_92_deployed" {
         code {
             mstore(64, 128)
 
@@ -36,7 +36,7 @@ object "c12_89" {
                     // test_call(address,uint256)
 
                     let param_0, param_1 :=  abi_decode_tuple_t_addresst_uint256(4, calldatasize())
-                    let ret_0 :=  fun_test_call_88(param_0, param_1)
+                    let ret_0 :=  fun_test_call_91(param_0, param_1)
                     let memPos := allocateMemory(0)
                     let memEnd := abi_encode_tuple_t_uint256__to_t_uint256__fromStack(memPos , ret_0)
                     return(memPos, sub(memEnd, memPos))
@@ -203,38 +203,41 @@ object "c12_89" {
 
             }
 
-            function fun_test_call_88(vloc_externalc_62, vloc_a_64) -> vloc_result_67 {
+            function fun_test_call_91(vloc_externalc_62, vloc_a_64) -> vloc_result_67 {
                 let zero_value_for_type_t_uint256_18 := zero_value_for_split_t_uint256()
                 vloc_result_67 := zero_value_for_type_t_uint256_18
 
                 let _19 := vloc_externalc_62
                 let expr_73 := _19
                 let expr_74_address := expr_73
+                let expr_76 := callvalue()
+                let expr_77_address := expr_74_address
+                let expr_77_value := expr_76
                 let _20 := vloc_a_64
-                let expr_78 := _20
+                let expr_81 := _20
 
-                let expr_79_mpos := allocateTemporaryMemory()
-                let _21 := add(expr_79_mpos, 0x20)
+                let expr_82_mpos := allocateTemporaryMemory()
+                let _21 := add(expr_82_mpos, 0x20)
 
                 mstore(_21, 0x66d29e6e00000000000000000000000000000000000000000000000000000000)
                 _21 := add(_21, 4)
 
-                let _22 := abi_encode_tuple_t_uint256__to_t_uint256__fromStack(_21, expr_78)
-                mstore(expr_79_mpos, sub(_22, add(expr_79_mpos, 0x20)))
+                let _22 := abi_encode_tuple_t_uint256__to_t_uint256__fromStack(_21, expr_81)
+                mstore(expr_82_mpos, sub(_22, add(expr_82_mpos, 0x20)))
                 mstore(64, round_up_to_mul_of_32(_22))
 
-                let _23 := add(expr_79_mpos, 0x20)
-                let _24 := mload(expr_79_mpos)
+                let _23 := add(expr_82_mpos, 0x20)
+                let _24 := mload(expr_82_mpos)
 
-                let expr_80_component_1 := call(gas(), expr_74_address,  0,  _23, _24, 0, 0)
+                let expr_83_component_1 := call(gas(), expr_77_address,  expr_77_value,  _23, _24, 0, 0)
 
-                let expr_80_component_2_mpos := extract_returndata()
+                let expr_83_component_2_mpos := extract_returndata()
 
-                let vloc_success_70 := expr_80_component_1
-                let vloc_data_72_mpos := expr_80_component_2_mpos
+                let vloc_success_70 := expr_83_component_1
+                let vloc_data_72_mpos := expr_83_component_2_mpos
                 let _25 := vloc_success_70
-                let expr_83 := _25
-                require_helper(expr_83)
+                let expr_86 := _25
+                require_helper(expr_86)
                 {
                     vloc_result_67 := mload(add(vloc_data_72_mpos, 32))
                 }

--- a/tests/contracts/c3.yul
+++ b/tests/contracts/c3.yul
@@ -24,7 +24,7 @@ object "TestWasm3" {
             let account := mload(add(_calldata, 32))
             mstore(slotPtr(data_ptr, 2), balance(account))
 
-            log0(slotPtr(data_ptr, 2), 32)
+            // log0(slotPtr(data_ptr, 2), 32)
 
             // getCallValue i32
             mstore(slotPtr(data_ptr, 3), callvalue())
@@ -43,10 +43,10 @@ object "TestWasm3" {
             // storageLoad
             mstore(slotPtr(data_ptr, 7), sload(0))
 
-             // getGasLeft i64
+            // getGasLeft i64
             mstore(slotPtr(data_ptr, 8), gas())
 
-            log2(slotPtr(data_ptr, 8), 32, 55555554, 55555553)
+            // log2(slotPtr(data_ptr, 8), 32, 55555554, 55555553)
 
             // getBlockHash
             mstore(slotPtr(data_ptr, 9), blockhash(2))
@@ -69,17 +69,16 @@ object "TestWasm3" {
             // getCodeSize
             mstore(slotPtr(data_ptr, 15), codesize())
 
-            log3(slotPtr(data_ptr, 15), 32, 55555552, 55555551, 55555550)
+            // log3(slotPtr(data_ptr, 15), 32, 55555552, 55555551, 55555550)
 
             let addr2 := mload(_calldata)
-
             mstore(slotPtr(data_ptr, 16), addr2)
 
             // getExternalCodeSize i32
             mstore(slotPtr(data_ptr, 17), extcodesize(addr2))
 
             // externalCodeCopy
-            extcodecopy(addr2, slotPtr(data_ptr, 18), 32, 32)
+            extcodecopy(addr2, slotPtr(data_ptr, 18), 0, 32)
 
             return (data_ptr, slotOffset(19))
 

--- a/tests/jsvm.test.js
+++ b/tests/jsvm.test.js
@@ -374,7 +374,7 @@ it('test c8 selfDestruct', async function () {
     expect(ewasmjsvm.getPersistence().get(runtime.address).runtimeCode).toBeUndefined();
 });
 
-it.skip('test c9 calls', async function () {
+it('test c9 calls', async function () {
     const runtime = await ewasmjsvm.deploy(contracts.c9.bin, c9Abi)(DEFAULT_TX_INFO);
     deployments.c9 = runtime;
 
@@ -389,30 +389,33 @@ it('test c10', async function () {
     const runtime = await ewasmjsvm.deploy(contracts.c10.bin, c10Abi)(DEFAULT_TX_INFO);
     deployments.c10 = runtime;
 
-    // let answ = await runtime.sum(8, 2, DEFAULT_TX_INFO);
-    // expect(answ.c.toNumber()).toBe(10);
+    let answ = await runtime.sum(8, 2, DEFAULT_TX_INFO);
+    expect(answ.c.toNumber()).toBe(10);
 
-    // answ = await runtime.testAddress(runtime.address, DEFAULT_TX_INFO);
-    // expect(answ[0].toLowerCase()).toBe(runtime.address);
+    answ = await runtime.testAddress(runtime.address, DEFAULT_TX_INFO);
+    expect(answ[0].toLowerCase()).toBe(runtime.address);
 
-    // let value = (await runtime.value(DEFAULT_TX_INFO))[0].toNumber();
-    // expect(value).toBe(5);
+    let value = (await runtime.value(DEFAULT_TX_INFO))[0].toNumber();
+    expect(value).toBe(5);
 
-    // let balance = ewasmjsvm.getPersistence().get(runtime.address).balance.toNumber();
+    let balance = ewasmjsvm.getPersistence().get(runtime.address).balance.toNumber();
 
-    // const newvalue = await runtime.addvalue(10, {...DEFAULT_TX_INFO, value: 40});
-    // value += 50;
-    // expect(newvalue[0].toNumber()).toBe(value);
+    const newvalue = await runtime.addvalue(10, {...DEFAULT_TX_INFO, value: 40});
+    value += 50;
+    expect(newvalue[0].toNumber()).toBe(value);
 
-    // const val = (await runtime.value(DEFAULT_TX_INFO))[0].toNumber();
-    // expect(val).toBe(value);
+    const val = (await runtime.value(DEFAULT_TX_INFO))[0].toNumber();
+    expect(val).toBe(value);
 
-    // const newbalance = ewasmjsvm.getPersistence().get(runtime.address).balance.toNumber();
-    // balance += 40;
-    // expect(newbalance).toBe(balance);
+    const newbalance = ewasmjsvm.getPersistence().get(runtime.address).balance.toNumber();
+    balance += 40;
+    expect(newbalance).toBe(balance);
 });
 
-it.skip('test c10 - calls solidity', async function () {
+it('test c10 - calls solidity', async function () {
+    const runtime = await ewasmjsvm.deploy(contracts.c10.bin, c10Abi)(DEFAULT_TX_INFO);
+    deployments.c10 = runtime;
+
     const _runtime = await ewasmjsvm.deploy(contracts.c12.bin, c12Abi)(DEFAULT_TX_INFO);
 
     let value = (await deployments.c10.value(DEFAULT_TX_INFO))[0].toNumber();
@@ -421,11 +424,11 @@ it.skip('test c10 - calls solidity', async function () {
     answ = await _runtime.test_staticcall(deployments.c10.address, 8, 2, DEFAULT_TX_INFO);
     expect(answ.c.toNumber()).toBe(10);
 
-    // answ = await _runtime.test_staticcall_address(deployments.c10.address, deployments.c10.address, DEFAULT_TX_INFO);
-    // expect(answ.c.toHex()).toBe(deployments.c10.address);
+    answ = await _runtime.test_staticcall_address(deployments.c10.address, deployments.c10.address, DEFAULT_TX_INFO);
+    expect(answ.c.toHexString()).toBe(deployments.c10.address);
 
-    // await _runtime.test_call(deployments.c10.address, 10, {...DEFAULT_TX_INFO, value: 40});
-    // const val2 = (await deployments.c10.value(DEFAULT_TX_INFO))[0].toNumber();
+    await _runtime.test_call(deployments.c10.address, 10, {...DEFAULT_TX_INFO, value: 40});
+    const val2 = (await deployments.c10.value({...DEFAULT_TX_INFO}))[0].toNumber();
     // expect(val2).toBe(value + 10 + 40);
 
     // const newbalance2 = ewasmjsvm.getPersistence().get(deployments.c10.address).balance.toNumber();

--- a/tests/jsvm.test.js
+++ b/tests/jsvm.test.js
@@ -69,21 +69,21 @@ describe.each([
         return;
     }, 20000);
 
-    it('test c1', async function () {
+    it('test c1 - simple fallback, just constructor', async function () {
         const runtime = await jsvm.runtimeSim(contracts.c1[field], contracts.c1.abi);
         deployments.c1 = runtime;
         const answ = await runtime.main({...DEFAULT_TX_INFO});
         expect(answ.val._hex).toBe('0xeeeeeeeeeeeeee');
     });
 
-    it('test c2', async function () {
+    it('test c2, simple fallback with constructor', async function () {
         const runtime = await jsvm.deploy(contracts.c2[field], contracts.c2.abi)({...DEFAULT_TX_INFO});
         deployments.c2 = runtime;
         const answ = await runtime.main({...DEFAULT_TX_INFO});
         expect(answ.val.toNumber()).toBe(999999);
     });
 
-    it('test c3 multi', async function () {
+    it('test c3 multiple opcodes', async function () {
         const tx_info = {...DEFAULT_TX_INFO, value: 1400};
         let fromBalance = jsvm.getPersistence().get(tx_info.from).balance;
         const runtime = await jsvm.deploy(contracts.c3[field], contracts.c3.abi)(tx_info);
@@ -223,7 +223,8 @@ describe.each([
         expect(jsvm.getPersistence().get(runtime.address).runtimeCode).toBeUndefined();
     });
 
-    it.skip('test c9 calls', async function () {
+    const itnested = name === 'evmjs' ? it : it.skip;
+    itnested('test c9 calls', async function () {
         const runtime = await jsvm.deploy(contracts.c9[field], contracts.c9.abi)(DEFAULT_TX_INFO);
         deployments.c9 = runtime;
 
@@ -234,7 +235,7 @@ describe.each([
         expect(answ[0]).toBe('0x00000000000000000000000000000000000000000000000000000000000f424900000000000000000000000000000000000000000000000000000000000f4249');
     });
 
-    it('test c10', async function () {
+    it('test c10 - simple functions', async function () {
         const runtime = await jsvm.deploy(contracts.c10[field], contracts.c10.abi)(DEFAULT_TX_INFO);
         deployments.c10 = runtime;
 
@@ -261,7 +262,7 @@ describe.each([
         expect(newbalance).toBe(balance);
     }, 5000);
 
-    it('test c10 - calls solidity', async function () {
+    it('test c10 - callStatic, call', async function () {
         const runtime = await jsvm.deploy(contracts.c10[field], contracts.c10.abi)(DEFAULT_TX_INFO);
         deployments.c10 = runtime;
 
@@ -275,7 +276,7 @@ describe.each([
         expect(jsvm.getPersistence().get(deployments.c10.address).balance.toNumber()).toBe(balance);
 
         answ = await _runtime.test_staticcall_address(deployments.c10.address, deployments.c10.address, DEFAULT_TX_INFO);
-        expect(answ.c.toHexString()).toBe(deployments.c10.address);
+        expect(eBN2addr(answ.c)).toBe(deployments.c10.address);
         expect(jsvm.getPersistence().get(deployments.c10.address).balance.toNumber()).toBe(balance);
 
         await _runtime.test_call(deployments.c10.address, 10, {...DEFAULT_TX_INFO, value: 40});
@@ -299,7 +300,7 @@ describe.each([
         expect(newbalance).toBe(balance);
     });
 
-    it('test c11', async function () {
+    it('test c11 - for loop', async function () {
         const runtime = await jsvm.deploy(contracts.c11[field], contracts.c2.abi)(DEFAULT_TX_INFO);
         let answ = await runtime.main( DEFAULT_TX_INFO);
         expect(answ.val.toNumber()).toBe(11);
@@ -344,3 +345,7 @@ it.skip('test taylor', async function () {
     // console.log(answ)
     // expect(answ.result).toBe('0xee000001000000081100000400000000');
 });
+
+function eBN2addr (n) {
+    return '0x' + strip0x(n.toHexString()).padLeft(40, '0');
+}

--- a/tests/jsvm.test.js
+++ b/tests/jsvm.test.js
@@ -1,11 +1,12 @@
 const fs = require('fs');
 const { exec } = require('child_process');
 const { ethers } = require('ethers');
-const { ewasmjsvm } = require('../src/index.js');
+const { ewasmjsvm: _ewasmjsvm } = require('../src/index.js');
 const utils = require('../src/utils.js');
 const { uint8ArrayToHex } = require('../src/utils.js');
-const Logger = require('../src/config');
+const {Logger} = require('../src/config');
 
+const ewasmjsvm = _ewasmjsvm();
 const checksum = ethers.utils.getAddress;
 const {toBN} = utils;
 

--- a/tests/jsvm.test.js
+++ b/tests/jsvm.test.js
@@ -2,7 +2,7 @@ const { ethers } = require('ethers');
 const { compileContracts } = require('./setup/setup');
 const { ewasmjsvm: _ewasmjsvm, evmjs: _evmjs } = require('../src/index.js');
 const utils = require('../src/utils.js');
-const { uint8ArrayToHex, hexToUint8Array } = require('../src/utils.js');
+const { uint8ArrayToHex, strip0x } = require('../src/utils.js');
 const {Logger} = require('../src/config');
 
 const ewasmjsvm = _ewasmjsvm();
@@ -347,5 +347,5 @@ it.skip('test taylor', async function () {
 });
 
 function eBN2addr (n) {
-    return '0x' + strip0x(n.toHexString()).padLeft(40, '0');
+    return '0x' + strip0x(n.toHexString()).padStart(40, '0');
 }

--- a/tests/jsvm.test.js
+++ b/tests/jsvm.test.js
@@ -1,12 +1,14 @@
 const fs = require('fs');
 const { exec } = require('child_process');
 const { ethers } = require('ethers');
-const { ewasmjsvm: _ewasmjsvm } = require('../src/index.js');
+const { ewasmjsvm: _ewasmjsvm, evmjs: _evmjs } = require('../src/index.js');
 const utils = require('../src/utils.js');
 const { uint8ArrayToHex } = require('../src/utils.js');
 const {Logger} = require('../src/config');
+const evm = require('../src/evm.js');
 
 const ewasmjsvm = _ewasmjsvm();
+const evmjs = _evmjs();
 const checksum = ethers.utils.getAddress;
 const {toBN} = utils;
 
@@ -15,6 +17,7 @@ const SOL_PATH = './tests/sol';
 const B_PATH = './tests/build';
 const solToYul = name => `solc --ir -o ${C_PATH} ${SOL_PATH}/${name}.sol --overwrite`;
 const yulToEwasm = name => `solc --strict-assembly --optimize --yul-dialect evm --machine ewasm ${C_PATH}/${name}.yul`;
+const yulToEvm = name => `solc --strict-assembly --optimize --yul-dialect evm --machine evm ${C_PATH}/${name}.yul`;
 // const yulToEwasm = name => `solc --strict-assembly --yul-dialect evm --machine ewasm ${C_PATH}/${name}.yul`;
 const watToWasm = name => `wat2wasm build_wat/${name}.wat -o build_wasm/${name}.wasm`;
 

--- a/tests/jsvm.test.js
+++ b/tests/jsvm.test.js
@@ -100,7 +100,7 @@ const c10Abi = [
     { name: 'double', type: 'function', inputs: [{ name: 'a', type: 'uint256'}], outputs: [{ name: 'b', type: 'uint256'}]},
     { name: 'value', type: 'function', inputs: [], outputs: [{ name: 'b', type: 'uint256'}]},
     { name: 'addvalue', type: 'function', inputs: [{ name: '_value', type: 'uint256'}], outputs: [{ name: 'b', type: 'uint256'}]},
-    { name: 'externalc', type: 'function', inputs: [], outputs: [{ name: '_externalc', type: 'address'}]},
+    { name: '_revert', type: 'function', inputs: [], outputs: []},
 
     { name: 'testAddress', type: 'function', inputs: [{ name: 'addr', type: 'address'}], outputs: [{ name: 'addr', type: 'address'}]},
 ]
@@ -374,7 +374,7 @@ it('test c8 selfDestruct', async function () {
     expect(ewasmjsvm.getPersistence().get(runtime.address).runtimeCode).toBeUndefined();
 });
 
-it('test c9 calls', async function () {
+it.skip('test c9 calls', async function () {
     const runtime = await ewasmjsvm.deploy(contracts.c9.bin, c9Abi)(DEFAULT_TX_INFO);
     deployments.c9 = runtime;
 
@@ -436,13 +436,13 @@ it('test c10 - calls solidity', async function () {
 });
 
 it.skip('test c10 revert', async function () {
-    const runtime = await ewasmjsvm.deploy(contracts.c10.bin, c10Abi)(DEFAULT_TX_INFO);
-    let value = (await runtime.value(DEFAULT_TX_INFO))[0].toNumber();
+    const runtime = await ewasmjsvm.deploy(contracts.c10.bin, c10Abi)({...DEFAULT_TX_INFO});
+    let value = (await runtime.value({...DEFAULT_TX_INFO}))[0].toNumber();
     let balance = ewasmjsvm.getPersistence().get(runtime.address).balance.toNumber();
 
-    await deployments.c10.addvalue(5, {...DEFAULT_TX_INFO, value: 40});
+    await expect(runtime._revert({...DEFAULT_TX_INFO, value: 40})).rejects.toThrow();
 
-    const val = (await runtime.value(DEFAULT_TX_INFO))[0].toNumber();
+    const val = (await runtime.value({...DEFAULT_TX_INFO}))[0].toNumber();
     expect(val).toBe(value);
 
     const newbalance = ewasmjsvm.getPersistence().get(runtime.address).balance.toNumber();

--- a/tests/setup/fixtures.js
+++ b/tests/setup/fixtures.js
@@ -1,0 +1,102 @@
+const c1 = [
+    { name: 'main', type: 'fallback', inputs: [], outputs: [{ name: 'val', type: 'uint256' }]},
+]
+
+const c2 = [
+    { name: 'constructor', type: 'constructor', inputs: [], outputs: []},
+    { name: 'main', type: 'fallback', inputs: [], outputs: [{ name: 'val', type: 'uint256' }]},
+]
+
+const c3 = [
+    { name: 'constructor', type: 'constructor', inputs: [], outputs: []},
+    { name: 'main', type: 'fallback', inputs: [
+        { name: 'addr', type: 'address' },
+        { name: 'account', type: 'address' },
+    ], outputs: [
+        { name: 'addr', type: 'address' },
+        { name: 'caller', type: 'address' },
+        { name: 'addr_balance', type: 'address' }, // 16  fix
+        { name: 'callvalue', type: 'uint16' },  // 16
+        { name: 'calldatasize', type: 'uint8' }, // 8
+        { name: 'origin', type: 'address' },  // 20
+        { name: 'difficulty', type: 'uint256' }, // 32
+        { name: 'stored_addr', type: 'address' }, // ?addr  fix
+        { name: 'gas_left', type: 'uint256' },
+        { name: 'blockhash', type: 'bytes32' }, // fix
+        { name: 'gaslimit', type: 'uint' },
+        { name: 'gasprice', type: 'uint' },
+        { name: 'number', type: 'uint' }, // fix
+        { name: 'timestamp', type: 'uint' },
+        { name: 'coinbase', type: 'address' },
+        { name: 'codesize', type: 'uint' },
+        { name: 'calldata', type: 'address' },
+        { name: 'extcodesize', type: 'uint' },
+        { name: 'extcodecopy', type: 'bytes32' },
+    ]},
+]
+
+const c4 = [
+    { name: 'constructor', type: 'constructor', inputs: [], outputs: []},
+    { name: 'main', type: 'fallback', inputs: [], outputs: [{ name: 'val', type: 'uint256' }]},
+]
+
+const c5 = [
+    { name: 'constructor', type: 'constructor', inputs: [], outputs: []},
+    { name: 'main', type: 'fallback', inputs: [], outputs: []},
+]
+
+const c6 = [
+    { name: 'constructor', type: 'constructor', inputs: [], outputs: []},
+    { name: 'main', type: 'fallback', inputs: [{ name: 'addr', type: 'address' }], outputs: [{ name: 'balance', type: 'uint' }]},
+]
+
+const c7 = [
+    { name: 'constructor', type: 'constructor', inputs: [], outputs: []},
+    { name: 'main', type: 'fallback', inputs: [], outputs: [{ name: 'addr', type: 'address' }]},
+]
+
+const c7b = [
+    { name: 'constructor', type: 'constructor', inputs: [], outputs: []},
+    { name: 'main', type: 'fallback', inputs: [{ name: 'calldata', type: 'bytes' }], outputs: [{ name: 'addr', type: 'address' }]},
+]
+
+const c8 = [
+    { name: 'constructor', type: 'constructor', inputs: [], outputs: []},
+    { name: 'main', type: 'fallback', inputs: [], outputs: []},
+]
+
+const c9 = [
+    { name: 'constructor', type: 'constructor', inputs: [], outputs: []},
+    { name: 'main', type: 'fallback', inputs: [{ name: 'addr', type: 'address'}, { name: 'addr2', type: 'address'}], outputs: [{ name: 'result', type: 'bytes'}]},
+]
+
+const c9_ = [
+    { name: 'constructor', type: 'constructor', inputs: [], outputs: []},
+    { name: 'main', type: 'fallback', inputs: [{ name: 'addr', type: 'address'}], outputs: [{ name: 'val', type: 'uint256' }]},
+]
+
+const c10 = [
+    { name: 'constructor', type: 'constructor', inputs: [], outputs: []},
+    { name: 'sum', type: 'function', inputs: [{ name: 'a', type: 'uint256'}, { name: 'b', type: 'uint256'}], outputs: [{ name: 'c', type: 'uint256'}]},
+    { name: 'double', type: 'function', inputs: [{ name: 'a', type: 'uint256'}], outputs: [{ name: 'b', type: 'uint256'}]},
+    { name: 'value', type: 'function', inputs: [], outputs: [{ name: 'b', type: 'uint256'}]},
+    { name: 'addvalue', type: 'function', inputs: [{ name: '_value', type: 'uint256'}], outputs: [{ name: 'b', type: 'uint256'}]},
+    { name: '_revert', type: 'function', inputs: [], outputs: []},
+
+    { name: 'testAddress', type: 'function', inputs: [{ name: 'addr', type: 'address'}], outputs: [{ name: 'addr', type: 'address'}]},
+]
+
+const c12 = [
+    // { name: 'constructor', type: 'constructor', inputs: [{ name: '_externalc', type: 'address'}], outputs: []},
+    { name: 'constructor', type: 'constructor', inputs: [], outputs: []},
+    { name: 'test_staticcall', type: 'function', inputs: [{ name: 'externalc', type: 'address'}, { name: 'a', type: 'uint256'}, { name: 'b', type: 'uint256'}], outputs: [{ name: 'c', type: 'uint256'}]},
+    { name: 'test_staticcall_address', type: 'function', inputs: [{ name: 'externalc', type: 'address'}, { name: 'addr', type: 'address'}], outputs: [{ name: 'c', type: 'uint256'}]},
+    { name: 'test_call', type: 'function', inputs: [{ name: 'externalc', type: 'address'}, { name: 'a', type: 'uint256'}], outputs: [{ name: 'result', type: 'uint256'}]},
+]
+
+const taylor = [
+    { name: 'constructor', type: 'constructor', inputs: [], outputs: []},
+    { name: 'main', type: 'fallback', inputs: [{ name: 'data', type: 'bytes'}], outputs: [{ name: 'result', type: 'bytes' }]},
+]
+
+module.exports = { c1, c2, c3, c4, c5, c6, c7, c7b, c8, c9, c9_, c10, c12 };

--- a/tests/setup/setup.js
+++ b/tests/setup/setup.js
@@ -1,0 +1,129 @@
+const fs = require('fs');
+const { exec } = require('child_process');
+const {promisify} = require('./utils');
+const abis = require('./fixtures');
+
+const C_PATH = './tests/contracts';
+const SOL_PATH = './tests/sol';
+const B_PATH = './tests/build';
+const solToYul = name => `solc --ir -o ${C_PATH} ${SOL_PATH}/${name}.sol --overwrite`;
+const yulToEwasm = name => `solc --strict-assembly --optimize --yul-dialect evm --machine ewasm ${C_PATH}/${name}.yul`;
+const yulToEvm = name => `solc --strict-assembly --optimize --yul-dialect evm --machine evm ${C_PATH}/${name}.yul`;
+// const yulToEwasm = name => `solc --strict-assembly --yul-dialect evm --machine ewasm ${C_PATH}/${name}.yul`;
+const watToWasm = name => `wat2wasm build_wat/${name}.wat -o build_wasm/${name}.wasm`;
+
+const compileEvm = name => new Promise((resolve, reject) => {
+    const command = yulToEvm(name);
+    exec(command, async (error, stdout, stderr) => {
+        if (error) {
+            console.log(`error: ${error.message}`);
+            reject(error);
+        }
+        if (stderr) {
+            // Logger.get('tests').get('compile').warn(stderr);
+            // reject(error);
+        }
+        // const filepath = `${B_PATH}/${name}.bin`;
+        // const bin = await promisify(fs.readFile, filepath).catch(console.log);
+        // resolve(bin);
+        resolve(parseCompilerOutput(stdout));
+    });
+});
+
+const compile = name => new Promise((resolve, reject) => {
+    const command = yulToEwasm(name);
+    // Logger.get('tests').get('compile').debug('Running command: ' + command);
+    exec(command, (error, stdout, stderr) => {
+        if (error) {
+            console.log(`error: ${error.message}`);
+            reject(error);
+        }
+        if (stderr) {
+            // Logger.get('tests').get('compile').warn(stderr);
+            // reject(error);
+        }
+        resolve(parseCompilerOutput(stdout));
+    });
+});
+
+const compileSol = name => new Promise((resolve, reject) => {
+    const command = solToYul(name);
+    // Logger.get('tests').get('compileSol').debug('Running command: ' + command);
+    exec(command, async (error, stdout, stderr) => {
+        if (error) {
+            console.log(`error: ${error.message}`);
+            reject(error);
+        }
+        if (stderr) {
+            // Logger.get('tests').get('compileSol').warn(stderr);
+        }
+        // The .yul file has been created
+        resolve();
+    });
+});
+
+async function createBuild(name, { bin, optimized, yul_wasm, wat}) {
+    const basePath = B_PATH + '/' + name + '_';
+
+    await promisify(fs.writeFile, basePath + 'bin', bin).catch(console.log);
+    await promisify(fs.writeFile, basePath + 'wat.wat', wat).catch(console.log);
+    await promisify(fs.writeFile, basePath + 'wasm.yul', yul_wasm).catch(console.log);
+    await promisify(fs.writeFile, basePath + 'opt.yul', optimized).catch(console.log);
+}
+
+function parseCompilerOutput(str) {
+    const bin = str.match(/Binary representation:\n(.*)\n/)[1];
+    const watm = str.match(/Text representation:\n((.*\n*)*)/);
+    const wat = watm[1];
+
+    const prettyIndex = postIndex(str, 'Pretty printed source:');
+    const yulWasmIndex = postIndex(str, 'Translated source:');
+    const binaryIndex = postIndex(str, 'Binary representation:');
+
+    const optimized = str.substring(prettyIndex.post, yulWasmIndex.pre);
+    const yul_wasm = str.substring(yulWasmIndex.post, binaryIndex.pre);
+    return {optimized, yul_wasm, bin, wat};
+}
+
+const postIndex = (str, marker) => {
+    const index = str.indexOf(marker);
+    return {
+        pre: index - 1,
+        post: index + marker.length + 1,
+    }
+}
+
+const compileContracts = async () => {
+    const contracts = {};
+
+    // Compile contracts
+    let sol_names = await promisify(fs.readdir, SOL_PATH).catch(console.log);
+    sol_names = sol_names.map(name => name.replace('.sol', ''));
+    for (name of sol_names) {
+        await compileSol(name);
+    }
+
+    let names = await promisify(fs.readdir, C_PATH).catch(console.log);
+    names = names.map(name => name.replace('.yul', ''));
+    names = names.filter(n => n !== 'taylor');  // takes too much time
+    // names = ['c11', 'c12']
+
+    for (name of names) {
+        contracts[name] = await compile(name);
+        createBuild(name, contracts[name]);
+        contracts[name].abi = abis[name];
+    }
+
+    // Compile to Evm
+    for (name of names) {
+        contracts[name].evm = (await compileEvm(name)).bin;
+    }
+    return contracts;
+}
+
+module.exports = {
+    compileEvm,
+    compile,
+    compileSol,
+    compileContracts,
+}

--- a/tests/setup/utils.js
+++ b/tests/setup/utils.js
@@ -1,0 +1,11 @@
+
+function promisify(func, ...args) {
+    return new Promise((resolve, reject) => {
+        func(...args, (error, result) => {
+            if (error) reject(error);
+            resolve(result);
+        })
+    });
+}
+
+module.exports = {promisify};

--- a/tests/sol/c10.sol
+++ b/tests/sol/c10.sol
@@ -16,7 +16,8 @@ contract c10 {
         return value;
     }
 
-    function addvalue_revert(uint256 _value) public payable returns (uint256) {
-        // revert();
+    function _revert() public payable returns (uint256) {
+        value = value + 10;
+        revert();
     }
 }

--- a/tests/sol/c12.sol
+++ b/tests/sol/c12.sol
@@ -24,7 +24,7 @@ contract c12 {
     }
 
     function test_call(address externalc, uint256 a) payable public returns (uint256 result) {
-        (bool success, bytes memory data) = externalc.call(abi.encodeWithSignature("addvalue(uint256)", a));
+        (bool success, bytes memory data) = externalc.call{value: msg.value}(abi.encodeWithSignature("addvalue(uint256)", a));
         require(success);
         assembly {
             result := mload(add(data, 32))


### PR DESCRIPTION
closes https://github.com/loredanacirstea/ewasm-jsvm/issues/2
fixes https://github.com/loredanacirstea/ewasm-jsvm/issues/3
fixes https://github.com/loredanacirstea/ewasm-jsvm/issues/13

partially fixes https://github.com/loredanacirstea/ewasm-jsvm/issues/6 for staticCall & call (todo delegateCall)


Refactor instantiation & restarting mechanism.
Support reverting transactions - pass parent context to children processes (internal calls) and only update persistent changes at the end.

Add evm1 simulator. Now it is slow because it follows the same principle as ewasm: the transaction is stopped and re-executed until all asynchronous resources are gathered in the context until all asynchronous calls have been executed.